### PR TITLE
update version and also use AWP_ROOT

### DIFF
--- a/ansys/systemcoupling/core/client/syc_process.py
+++ b/ansys/systemcoupling/core/client/syc_process.py
@@ -12,7 +12,9 @@ from ansys.systemcoupling.core.util.logging import LOG
 
 _isWindows = any(platform.win32_ver())
 
-_INSTALL_ROOT = "AWP_ROOT222"
+_CURR_VER = "231"
+_INSTALL_ROOT_ENV = "AWP_ROOT"
+_INSTALL_ROOT_VER_ENV = _INSTALL_ROOT_ENV + _CURR_VER
 _SC_ROOT_ENV = "SYSC_ROOT"
 
 _SCRIPT_EXT = ".bat" if _isWindows else ""
@@ -62,7 +64,9 @@ def _path_to_system_coupling():
     scroot = os.environ.get(_SC_ROOT_ENV, None)
 
     if not scroot:
-        scroot = os.environ.get(_INSTALL_ROOT, None)
+        scroot = os.environ.get(_INSTALL_ROOT_ENV, None)
+        if scroot is None:
+            scroot = os.environ.get(_INSTALL_ROOT_VER_ENV, None)
         if scroot:
             scroot = os.path.join(scroot, "SystemCoupling")
 


### PR DESCRIPTION
Hardcoded "current version" was still at  222. Update to 231.
This hadn't mattered until now as we couldn't use unified build anyway due to missing CPython packages. This is in the process of being rectified.

Also extend logic to try to use AWP_ROOT if that has been set.