### PR TITLE
add enter and exit functions for analysis object to support with syntax

### DIFF
--- a/ansys/systemcoupling/core/analysis.py
+++ b/ansys/systemcoupling/core/analysis.py
@@ -160,3 +160,9 @@ class SycAnalysis:
         if self.__native_api is None:
             self.__native_api = NativeApi(self.__rpc_impl)
         return self.__native_api
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.exit()


### PR DESCRIPTION
The top-level analysis object represents an instance of System Coupling, so it is natural to treat is as a resource holder. Python has a convenient with syntax to deal with acquiring resources. To support this syntax, the analysis object needs to define `__enter__` and `__exit__` functions, which is what is being changed here.