### PR TITLE
Fix package name in proto file to fix conflict with Fluent

### DIFF
--- a/ansys/api/systemcoupling/v0/command_pb2.py
+++ b/ansys/api/systemcoupling/v0/command_pb2.py
@@ -16,11 +16,11 @@ import ansys.api.systemcoupling.v0.variant_pb2 as variant__pb2
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='command.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\rcommand.proto\x12\x03syc\x1a\rvariant.proto\"\x82\x01\n\x0e\x43ommandRequest\x12\x0f\n\x07\x63ommand\x18\x01 \x01(\t\x12*\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\x1c.syc.CommandRequest.Argument\x1a\x33\n\x08\x41rgument\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x19\n\x03val\x18\x02 \x01(\x0b\x32\x0c.syc.Variant\"/\n\x0f\x43ommandResponse\x12\x1c\n\x06result\x18\x01 \x01(\x0b\x32\x0c.syc.Variant2G\n\x07\x43ommand\x12<\n\rInvokeCommand\x12\x13.syc.CommandRequest\x1a\x14.syc.CommandResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\rcommand.proto\x12\x1b\x61nsys.api.systemcoupling.v0\x1a\rvariant.proto\"\xb2\x01\n\x0e\x43ommandRequest\x12\x0f\n\x07\x63ommand\x18\x01 \x01(\t\x12\x42\n\x04\x61rgs\x18\x02 \x03(\x0b\x32\x34.ansys.api.systemcoupling.v0.CommandRequest.Argument\x1aK\n\x08\x41rgument\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x31\n\x03val\x18\x02 \x01(\x0b\x32$.ansys.api.systemcoupling.v0.Variant\"G\n\x0f\x43ommandResponse\x12\x34\n\x06result\x18\x01 \x01(\x0b\x32$.ansys.api.systemcoupling.v0.Variant2w\n\x07\x43ommand\x12l\n\rInvokeCommand\x12+.ansys.api.systemcoupling.v0.CommandRequest\x1a,.ansys.api.systemcoupling.v0.CommandResponse\"\x00\x62\x06proto3'
   ,
   dependencies=[variant__pb2.DESCRIPTOR,])
 
@@ -29,21 +29,21 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _COMMANDREQUEST_ARGUMENT = _descriptor.Descriptor(
   name='Argument',
-  full_name='syc.CommandRequest.Argument',
+  full_name='ansys.api.systemcoupling.v0.CommandRequest.Argument',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='syc.CommandRequest.Argument.name', index=0,
+      name='name', full_name='ansys.api.systemcoupling.v0.CommandRequest.Argument.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='val', full_name='syc.CommandRequest.Argument.val', index=1,
+      name='val', full_name='ansys.api.systemcoupling.v0.CommandRequest.Argument.val', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -61,27 +61,27 @@ _COMMANDREQUEST_ARGUMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=117,
-  serialized_end=168,
+  serialized_start=165,
+  serialized_end=240,
 )
 
 _COMMANDREQUEST = _descriptor.Descriptor(
   name='CommandRequest',
-  full_name='syc.CommandRequest',
+  full_name='ansys.api.systemcoupling.v0.CommandRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='command', full_name='syc.CommandRequest.command', index=0,
+      name='command', full_name='ansys.api.systemcoupling.v0.CommandRequest.command', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='args', full_name='syc.CommandRequest.args', index=1,
+      name='args', full_name='ansys.api.systemcoupling.v0.CommandRequest.args', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -99,21 +99,21 @@ _COMMANDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=38,
-  serialized_end=168,
+  serialized_start=62,
+  serialized_end=240,
 )
 
 
 _COMMANDRESPONSE = _descriptor.Descriptor(
   name='CommandResponse',
-  full_name='syc.CommandResponse',
+  full_name='ansys.api.systemcoupling.v0.CommandResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='result', full_name='syc.CommandResponse.result', index=0,
+      name='result', full_name='ansys.api.systemcoupling.v0.CommandResponse.result', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -131,8 +131,8 @@ _COMMANDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=170,
-  serialized_end=217,
+  serialized_start=242,
+  serialized_end=313,
 )
 
 _COMMANDREQUEST_ARGUMENT.fields_by_name['val'].message_type = variant__pb2._VARIANT
@@ -148,12 +148,12 @@ CommandRequest = _reflection.GeneratedProtocolMessageType('CommandRequest', (_me
   'Argument' : _reflection.GeneratedProtocolMessageType('Argument', (_message.Message,), {
     'DESCRIPTOR' : _COMMANDREQUEST_ARGUMENT,
     '__module__' : 'command_pb2'
-    # @@protoc_insertion_point(class_scope:syc.CommandRequest.Argument)
+    # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.CommandRequest.Argument)
     })
   ,
   'DESCRIPTOR' : _COMMANDREQUEST,
   '__module__' : 'command_pb2'
-  # @@protoc_insertion_point(class_scope:syc.CommandRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.CommandRequest)
   })
 _sym_db.RegisterMessage(CommandRequest)
 _sym_db.RegisterMessage(CommandRequest.Argument)
@@ -161,7 +161,7 @@ _sym_db.RegisterMessage(CommandRequest.Argument)
 CommandResponse = _reflection.GeneratedProtocolMessageType('CommandResponse', (_message.Message,), {
   'DESCRIPTOR' : _COMMANDRESPONSE,
   '__module__' : 'command_pb2'
-  # @@protoc_insertion_point(class_scope:syc.CommandResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.CommandResponse)
   })
 _sym_db.RegisterMessage(CommandResponse)
 
@@ -169,17 +169,17 @@ _sym_db.RegisterMessage(CommandResponse)
 
 _COMMAND = _descriptor.ServiceDescriptor(
   name='Command',
-  full_name='syc.Command',
+  full_name='ansys.api.systemcoupling.v0.Command',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=219,
-  serialized_end=290,
+  serialized_start=315,
+  serialized_end=434,
   methods=[
   _descriptor.MethodDescriptor(
     name='InvokeCommand',
-    full_name='syc.Command.InvokeCommand',
+    full_name='ansys.api.systemcoupling.v0.Command.InvokeCommand',
     index=0,
     containing_service=None,
     input_type=_COMMANDREQUEST,

--- a/ansys/api/systemcoupling/v0/command_pb2_grpc.py
+++ b/ansys/api/systemcoupling/v0/command_pb2_grpc.py
@@ -15,7 +15,7 @@ class CommandStub(object):
             channel: A grpc.Channel.
         """
         self.InvokeCommand = channel.unary_unary(
-                '/syc.Command/InvokeCommand',
+                '/ansys.api.systemcoupling.v0.Command/InvokeCommand',
                 request_serializer=command__pb2.CommandRequest.SerializeToString,
                 response_deserializer=command__pb2.CommandResponse.FromString,
                 )
@@ -40,7 +40,7 @@ def add_CommandServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'syc.Command', rpc_method_handlers)
+            'ansys.api.systemcoupling.v0.Command', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -58,7 +58,7 @@ class Command(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Command/InvokeCommand',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Command/InvokeCommand',
             command__pb2.CommandRequest.SerializeToString,
             command__pb2.CommandResponse.FromString,
             options, channel_credentials,

--- a/ansys/api/systemcoupling/v0/error_pb2.py
+++ b/ansys/api/systemcoupling/v0/error_pb2.py
@@ -15,11 +15,11 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='error.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0b\x65rror.proto\x12\x03syc\"@\n\x0c\x45rrorDetails\x12\x1b\n\x13\x65xception_classname\x18\x01 \x01(\t\x12\x13\n\x0bstack_trace\x18\x02 \x01(\tb\x06proto3'
+  serialized_pb=b'\n\x0b\x65rror.proto\x12\x1b\x61nsys.api.systemcoupling.v0\"@\n\x0c\x45rrorDetails\x12\x1b\n\x13\x65xception_classname\x18\x01 \x01(\t\x12\x13\n\x0bstack_trace\x18\x02 \x01(\tb\x06proto3'
 )
 
 
@@ -27,21 +27,21 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _ERRORDETAILS = _descriptor.Descriptor(
   name='ErrorDetails',
-  full_name='syc.ErrorDetails',
+  full_name='ansys.api.systemcoupling.v0.ErrorDetails',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='exception_classname', full_name='syc.ErrorDetails.exception_classname', index=0,
+      name='exception_classname', full_name='ansys.api.systemcoupling.v0.ErrorDetails.exception_classname', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='stack_trace', full_name='syc.ErrorDetails.stack_trace', index=1,
+      name='stack_trace', full_name='ansys.api.systemcoupling.v0.ErrorDetails.stack_trace', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -59,8 +59,8 @@ _ERRORDETAILS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=20,
-  serialized_end=84,
+  serialized_start=44,
+  serialized_end=108,
 )
 
 DESCRIPTOR.message_types_by_name['ErrorDetails'] = _ERRORDETAILS
@@ -69,7 +69,7 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 ErrorDetails = _reflection.GeneratedProtocolMessageType('ErrorDetails', (_message.Message,), {
   'DESCRIPTOR' : _ERRORDETAILS,
   '__module__' : 'error_pb2'
-  # @@protoc_insertion_point(class_scope:syc.ErrorDetails)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.ErrorDetails)
   })
 _sym_db.RegisterMessage(ErrorDetails)
 

--- a/ansys/api/systemcoupling/v0/output_stream_pb2.py
+++ b/ansys/api/systemcoupling/v0/output_stream_pb2.py
@@ -15,11 +15,11 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='output_stream.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x13output_stream.proto\x12\x03syc\"\x12\n\x10StdStreamRequest\"!\n\x11StdStreamResponse\x12\x0c\n\x04text\x18\x01 \x01(\t2V\n\x0cOutputStream\x12\x46\n\x11\x42\x65ginStdStreaming\x12\x15.syc.StdStreamRequest\x1a\x16.syc.StdStreamResponse\"\x00\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n\x13output_stream.proto\x12\x1b\x61nsys.api.systemcoupling.v0\"\x12\n\x10StdStreamRequest\"!\n\x11StdStreamResponse\x12\x0c\n\x04text\x18\x01 \x01(\t2\x86\x01\n\x0cOutputStream\x12v\n\x11\x42\x65ginStdStreaming\x12-.ansys.api.systemcoupling.v0.StdStreamRequest\x1a..ansys.api.systemcoupling.v0.StdStreamResponse\"\x00\x30\x01\x62\x06proto3'
 )
 
 
@@ -27,7 +27,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _STDSTREAMREQUEST = _descriptor.Descriptor(
   name='StdStreamRequest',
-  full_name='syc.StdStreamRequest',
+  full_name='ansys.api.systemcoupling.v0.StdStreamRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -45,21 +45,21 @@ _STDSTREAMREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=28,
-  serialized_end=46,
+  serialized_start=52,
+  serialized_end=70,
 )
 
 
 _STDSTREAMRESPONSE = _descriptor.Descriptor(
   name='StdStreamResponse',
-  full_name='syc.StdStreamResponse',
+  full_name='ansys.api.systemcoupling.v0.StdStreamResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='text', full_name='syc.StdStreamResponse.text', index=0,
+      name='text', full_name='ansys.api.systemcoupling.v0.StdStreamResponse.text', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -77,8 +77,8 @@ _STDSTREAMRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=48,
-  serialized_end=81,
+  serialized_start=72,
+  serialized_end=105,
 )
 
 DESCRIPTOR.message_types_by_name['StdStreamRequest'] = _STDSTREAMREQUEST
@@ -88,14 +88,14 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 StdStreamRequest = _reflection.GeneratedProtocolMessageType('StdStreamRequest', (_message.Message,), {
   'DESCRIPTOR' : _STDSTREAMREQUEST,
   '__module__' : 'output_stream_pb2'
-  # @@protoc_insertion_point(class_scope:syc.StdStreamRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.StdStreamRequest)
   })
 _sym_db.RegisterMessage(StdStreamRequest)
 
 StdStreamResponse = _reflection.GeneratedProtocolMessageType('StdStreamResponse', (_message.Message,), {
   'DESCRIPTOR' : _STDSTREAMRESPONSE,
   '__module__' : 'output_stream_pb2'
-  # @@protoc_insertion_point(class_scope:syc.StdStreamResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.StdStreamResponse)
   })
 _sym_db.RegisterMessage(StdStreamResponse)
 
@@ -103,17 +103,17 @@ _sym_db.RegisterMessage(StdStreamResponse)
 
 _OUTPUTSTREAM = _descriptor.ServiceDescriptor(
   name='OutputStream',
-  full_name='syc.OutputStream',
+  full_name='ansys.api.systemcoupling.v0.OutputStream',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=83,
-  serialized_end=169,
+  serialized_start=108,
+  serialized_end=242,
   methods=[
   _descriptor.MethodDescriptor(
     name='BeginStdStreaming',
-    full_name='syc.OutputStream.BeginStdStreaming',
+    full_name='ansys.api.systemcoupling.v0.OutputStream.BeginStdStreaming',
     index=0,
     containing_service=None,
     input_type=_STDSTREAMREQUEST,

--- a/ansys/api/systemcoupling/v0/output_stream_pb2_grpc.py
+++ b/ansys/api/systemcoupling/v0/output_stream_pb2_grpc.py
@@ -15,7 +15,7 @@ class OutputStreamStub(object):
             channel: A grpc.Channel.
         """
         self.BeginStdStreaming = channel.unary_stream(
-                '/syc.OutputStream/BeginStdStreaming',
+                '/ansys.api.systemcoupling.v0.OutputStream/BeginStdStreaming',
                 request_serializer=output__stream__pb2.StdStreamRequest.SerializeToString,
                 response_deserializer=output__stream__pb2.StdStreamResponse.FromString,
                 )
@@ -40,7 +40,7 @@ def add_OutputStreamServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'syc.OutputStream', rpc_method_handlers)
+            'ansys.api.systemcoupling.v0.OutputStream', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -58,7 +58,7 @@ class OutputStream(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_stream(request, target, '/syc.OutputStream/BeginStdStreaming',
+        return grpc.experimental.unary_stream(request, target, '/ansys.api.systemcoupling.v0.OutputStream/BeginStdStreaming',
             output__stream__pb2.StdStreamRequest.SerializeToString,
             output__stream__pb2.StdStreamResponse.FromString,
             options, channel_credentials,

--- a/ansys/api/systemcoupling/v0/process_pb2.py
+++ b/ansys/api/systemcoupling/v0/process_pb2.py
@@ -15,11 +15,11 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='process.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\rprocess.proto\x12\x03syc\"\r\n\x0bPingRequest\"\x0e\n\x0cPingResponse\"\r\n\x0bQuitRequest\"\x0e\n\x0cQuitResponse2g\n\x07Process\x12-\n\x04Ping\x12\x10.syc.PingRequest\x1a\x11.syc.PingResponse\"\x00\x12-\n\x04Quit\x12\x10.syc.QuitRequest\x1a\x11.syc.QuitResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\rprocess.proto\x12\x1b\x61nsys.api.systemcoupling.v0\"\r\n\x0bPingRequest\"\x0e\n\x0cPingResponse\"\r\n\x0bQuitRequest\"\x0e\n\x0cQuitResponse2\xc7\x01\n\x07Process\x12]\n\x04Ping\x12(.ansys.api.systemcoupling.v0.PingRequest\x1a).ansys.api.systemcoupling.v0.PingResponse\"\x00\x12]\n\x04Quit\x12(.ansys.api.systemcoupling.v0.QuitRequest\x1a).ansys.api.systemcoupling.v0.QuitResponse\"\x00\x62\x06proto3'
 )
 
 
@@ -27,7 +27,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _PINGREQUEST = _descriptor.Descriptor(
   name='PingRequest',
-  full_name='syc.PingRequest',
+  full_name='ansys.api.systemcoupling.v0.PingRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -45,14 +45,14 @@ _PINGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=22,
-  serialized_end=35,
+  serialized_start=46,
+  serialized_end=59,
 )
 
 
 _PINGRESPONSE = _descriptor.Descriptor(
   name='PingResponse',
-  full_name='syc.PingResponse',
+  full_name='ansys.api.systemcoupling.v0.PingResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -70,14 +70,14 @@ _PINGRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=37,
-  serialized_end=51,
+  serialized_start=61,
+  serialized_end=75,
 )
 
 
 _QUITREQUEST = _descriptor.Descriptor(
   name='QuitRequest',
-  full_name='syc.QuitRequest',
+  full_name='ansys.api.systemcoupling.v0.QuitRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -95,14 +95,14 @@ _QUITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=53,
-  serialized_end=66,
+  serialized_start=77,
+  serialized_end=90,
 )
 
 
 _QUITRESPONSE = _descriptor.Descriptor(
   name='QuitResponse',
-  full_name='syc.QuitResponse',
+  full_name='ansys.api.systemcoupling.v0.QuitResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -120,8 +120,8 @@ _QUITRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=68,
-  serialized_end=82,
+  serialized_start=92,
+  serialized_end=106,
 )
 
 DESCRIPTOR.message_types_by_name['PingRequest'] = _PINGREQUEST
@@ -133,28 +133,28 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 PingRequest = _reflection.GeneratedProtocolMessageType('PingRequest', (_message.Message,), {
   'DESCRIPTOR' : _PINGREQUEST,
   '__module__' : 'process_pb2'
-  # @@protoc_insertion_point(class_scope:syc.PingRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.PingRequest)
   })
 _sym_db.RegisterMessage(PingRequest)
 
 PingResponse = _reflection.GeneratedProtocolMessageType('PingResponse', (_message.Message,), {
   'DESCRIPTOR' : _PINGRESPONSE,
   '__module__' : 'process_pb2'
-  # @@protoc_insertion_point(class_scope:syc.PingResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.PingResponse)
   })
 _sym_db.RegisterMessage(PingResponse)
 
 QuitRequest = _reflection.GeneratedProtocolMessageType('QuitRequest', (_message.Message,), {
   'DESCRIPTOR' : _QUITREQUEST,
   '__module__' : 'process_pb2'
-  # @@protoc_insertion_point(class_scope:syc.QuitRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.QuitRequest)
   })
 _sym_db.RegisterMessage(QuitRequest)
 
 QuitResponse = _reflection.GeneratedProtocolMessageType('QuitResponse', (_message.Message,), {
   'DESCRIPTOR' : _QUITRESPONSE,
   '__module__' : 'process_pb2'
-  # @@protoc_insertion_point(class_scope:syc.QuitResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.QuitResponse)
   })
 _sym_db.RegisterMessage(QuitResponse)
 
@@ -162,17 +162,17 @@ _sym_db.RegisterMessage(QuitResponse)
 
 _PROCESS = _descriptor.ServiceDescriptor(
   name='Process',
-  full_name='syc.Process',
+  full_name='ansys.api.systemcoupling.v0.Process',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=84,
-  serialized_end=187,
+  serialized_start=109,
+  serialized_end=308,
   methods=[
   _descriptor.MethodDescriptor(
     name='Ping',
-    full_name='syc.Process.Ping',
+    full_name='ansys.api.systemcoupling.v0.Process.Ping',
     index=0,
     containing_service=None,
     input_type=_PINGREQUEST,
@@ -182,7 +182,7 @@ _PROCESS = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='Quit',
-    full_name='syc.Process.Quit',
+    full_name='ansys.api.systemcoupling.v0.Process.Quit',
     index=1,
     containing_service=None,
     input_type=_QUITREQUEST,

--- a/ansys/api/systemcoupling/v0/process_pb2_grpc.py
+++ b/ansys/api/systemcoupling/v0/process_pb2_grpc.py
@@ -15,12 +15,12 @@ class ProcessStub(object):
             channel: A grpc.Channel.
         """
         self.Ping = channel.unary_unary(
-                '/syc.Process/Ping',
+                '/ansys.api.systemcoupling.v0.Process/Ping',
                 request_serializer=process__pb2.PingRequest.SerializeToString,
                 response_deserializer=process__pb2.PingResponse.FromString,
                 )
         self.Quit = channel.unary_unary(
-                '/syc.Process/Quit',
+                '/ansys.api.systemcoupling.v0.Process/Quit',
                 request_serializer=process__pb2.QuitRequest.SerializeToString,
                 response_deserializer=process__pb2.QuitResponse.FromString,
                 )
@@ -56,7 +56,7 @@ def add_ProcessServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'syc.Process', rpc_method_handlers)
+            'ansys.api.systemcoupling.v0.Process', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -74,7 +74,7 @@ class Process(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Process/Ping',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Process/Ping',
             process__pb2.PingRequest.SerializeToString,
             process__pb2.PingResponse.FromString,
             options, channel_credentials,
@@ -90,7 +90,7 @@ class Process(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Process/Quit',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Process/Quit',
             process__pb2.QuitRequest.SerializeToString,
             process__pb2.QuitResponse.FromString,
             options, channel_credentials,

--- a/ansys/api/systemcoupling/v0/solution_pb2.py
+++ b/ansys/api/systemcoupling/v0/solution_pb2.py
@@ -15,11 +15,11 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='solution.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0esolution.proto\x12\x03syc\"\x0e\n\x0cSolveRequest\"\x0f\n\rSolveResponse\"\"\n\x10InterruptRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\"\x13\n\x11InterruptResponse\"\x1e\n\x0c\x41\x62ortRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\"\x0f\n\rAbortResponse2\xac\x01\n\x08Solution\x12\x30\n\x05Solve\x12\x11.syc.SolveRequest\x1a\x12.syc.SolveResponse\"\x00\x12<\n\tInterrupt\x12\x15.syc.InterruptRequest\x1a\x16.syc.InterruptResponse\"\x00\x12\x30\n\x05\x41\x62ort\x12\x11.syc.AbortRequest\x1a\x12.syc.AbortResponse\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0esolution.proto\x12\x1b\x61nsys.api.systemcoupling.v0\"\x0e\n\x0cSolveRequest\"\x0f\n\rSolveResponse\"\"\n\x10InterruptRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\"\x13\n\x11InterruptResponse\"\x1e\n\x0c\x41\x62ortRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\"\x0f\n\rAbortResponse2\xbc\x02\n\x08Solution\x12`\n\x05Solve\x12).ansys.api.systemcoupling.v0.SolveRequest\x1a*.ansys.api.systemcoupling.v0.SolveResponse\"\x00\x12l\n\tInterrupt\x12-.ansys.api.systemcoupling.v0.InterruptRequest\x1a..ansys.api.systemcoupling.v0.InterruptResponse\"\x00\x12`\n\x05\x41\x62ort\x12).ansys.api.systemcoupling.v0.AbortRequest\x1a*.ansys.api.systemcoupling.v0.AbortResponse\"\x00\x62\x06proto3'
 )
 
 
@@ -27,7 +27,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
 
 _SOLVEREQUEST = _descriptor.Descriptor(
   name='SolveRequest',
-  full_name='syc.SolveRequest',
+  full_name='ansys.api.systemcoupling.v0.SolveRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -45,14 +45,14 @@ _SOLVEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=23,
-  serialized_end=37,
+  serialized_start=47,
+  serialized_end=61,
 )
 
 
 _SOLVERESPONSE = _descriptor.Descriptor(
   name='SolveResponse',
-  full_name='syc.SolveResponse',
+  full_name='ansys.api.systemcoupling.v0.SolveResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -70,21 +70,21 @@ _SOLVERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=39,
-  serialized_end=54,
+  serialized_start=63,
+  serialized_end=78,
 )
 
 
 _INTERRUPTREQUEST = _descriptor.Descriptor(
   name='InterruptRequest',
-  full_name='syc.InterruptRequest',
+  full_name='ansys.api.systemcoupling.v0.InterruptRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='reason', full_name='syc.InterruptRequest.reason', index=0,
+      name='reason', full_name='ansys.api.systemcoupling.v0.InterruptRequest.reason', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -102,14 +102,14 @@ _INTERRUPTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=56,
-  serialized_end=90,
+  serialized_start=80,
+  serialized_end=114,
 )
 
 
 _INTERRUPTRESPONSE = _descriptor.Descriptor(
   name='InterruptResponse',
-  full_name='syc.InterruptResponse',
+  full_name='ansys.api.systemcoupling.v0.InterruptResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -127,21 +127,21 @@ _INTERRUPTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=92,
-  serialized_end=111,
+  serialized_start=116,
+  serialized_end=135,
 )
 
 
 _ABORTREQUEST = _descriptor.Descriptor(
   name='AbortRequest',
-  full_name='syc.AbortRequest',
+  full_name='ansys.api.systemcoupling.v0.AbortRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='reason', full_name='syc.AbortRequest.reason', index=0,
+      name='reason', full_name='ansys.api.systemcoupling.v0.AbortRequest.reason', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -159,14 +159,14 @@ _ABORTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=113,
-  serialized_end=143,
+  serialized_start=137,
+  serialized_end=167,
 )
 
 
 _ABORTRESPONSE = _descriptor.Descriptor(
   name='AbortResponse',
-  full_name='syc.AbortResponse',
+  full_name='ansys.api.systemcoupling.v0.AbortResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -184,8 +184,8 @@ _ABORTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=145,
-  serialized_end=160,
+  serialized_start=169,
+  serialized_end=184,
 )
 
 DESCRIPTOR.message_types_by_name['SolveRequest'] = _SOLVEREQUEST
@@ -199,42 +199,42 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 SolveRequest = _reflection.GeneratedProtocolMessageType('SolveRequest', (_message.Message,), {
   'DESCRIPTOR' : _SOLVEREQUEST,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.SolveRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.SolveRequest)
   })
 _sym_db.RegisterMessage(SolveRequest)
 
 SolveResponse = _reflection.GeneratedProtocolMessageType('SolveResponse', (_message.Message,), {
   'DESCRIPTOR' : _SOLVERESPONSE,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.SolveResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.SolveResponse)
   })
 _sym_db.RegisterMessage(SolveResponse)
 
 InterruptRequest = _reflection.GeneratedProtocolMessageType('InterruptRequest', (_message.Message,), {
   'DESCRIPTOR' : _INTERRUPTREQUEST,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.InterruptRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.InterruptRequest)
   })
 _sym_db.RegisterMessage(InterruptRequest)
 
 InterruptResponse = _reflection.GeneratedProtocolMessageType('InterruptResponse', (_message.Message,), {
   'DESCRIPTOR' : _INTERRUPTRESPONSE,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.InterruptResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.InterruptResponse)
   })
 _sym_db.RegisterMessage(InterruptResponse)
 
 AbortRequest = _reflection.GeneratedProtocolMessageType('AbortRequest', (_message.Message,), {
   'DESCRIPTOR' : _ABORTREQUEST,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.AbortRequest)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.AbortRequest)
   })
 _sym_db.RegisterMessage(AbortRequest)
 
 AbortResponse = _reflection.GeneratedProtocolMessageType('AbortResponse', (_message.Message,), {
   'DESCRIPTOR' : _ABORTRESPONSE,
   '__module__' : 'solution_pb2'
-  # @@protoc_insertion_point(class_scope:syc.AbortResponse)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.AbortResponse)
   })
 _sym_db.RegisterMessage(AbortResponse)
 
@@ -242,17 +242,17 @@ _sym_db.RegisterMessage(AbortResponse)
 
 _SOLUTION = _descriptor.ServiceDescriptor(
   name='Solution',
-  full_name='syc.Solution',
+  full_name='ansys.api.systemcoupling.v0.Solution',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=163,
-  serialized_end=335,
+  serialized_start=187,
+  serialized_end=503,
   methods=[
   _descriptor.MethodDescriptor(
     name='Solve',
-    full_name='syc.Solution.Solve',
+    full_name='ansys.api.systemcoupling.v0.Solution.Solve',
     index=0,
     containing_service=None,
     input_type=_SOLVEREQUEST,
@@ -262,7 +262,7 @@ _SOLUTION = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='Interrupt',
-    full_name='syc.Solution.Interrupt',
+    full_name='ansys.api.systemcoupling.v0.Solution.Interrupt',
     index=1,
     containing_service=None,
     input_type=_INTERRUPTREQUEST,
@@ -272,7 +272,7 @@ _SOLUTION = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='Abort',
-    full_name='syc.Solution.Abort',
+    full_name='ansys.api.systemcoupling.v0.Solution.Abort',
     index=2,
     containing_service=None,
     input_type=_ABORTREQUEST,

--- a/ansys/api/systemcoupling/v0/solution_pb2_grpc.py
+++ b/ansys/api/systemcoupling/v0/solution_pb2_grpc.py
@@ -15,17 +15,17 @@ class SolutionStub(object):
             channel: A grpc.Channel.
         """
         self.Solve = channel.unary_unary(
-                '/syc.Solution/Solve',
+                '/ansys.api.systemcoupling.v0.Solution/Solve',
                 request_serializer=solution__pb2.SolveRequest.SerializeToString,
                 response_deserializer=solution__pb2.SolveResponse.FromString,
                 )
         self.Interrupt = channel.unary_unary(
-                '/syc.Solution/Interrupt',
+                '/ansys.api.systemcoupling.v0.Solution/Interrupt',
                 request_serializer=solution__pb2.InterruptRequest.SerializeToString,
                 response_deserializer=solution__pb2.InterruptResponse.FromString,
                 )
         self.Abort = channel.unary_unary(
-                '/syc.Solution/Abort',
+                '/ansys.api.systemcoupling.v0.Solution/Abort',
                 request_serializer=solution__pb2.AbortRequest.SerializeToString,
                 response_deserializer=solution__pb2.AbortResponse.FromString,
                 )
@@ -72,7 +72,7 @@ def add_SolutionServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'syc.Solution', rpc_method_handlers)
+            'ansys.api.systemcoupling.v0.Solution', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -90,7 +90,7 @@ class Solution(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Solution/Solve',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Solution/Solve',
             solution__pb2.SolveRequest.SerializeToString,
             solution__pb2.SolveResponse.FromString,
             options, channel_credentials,
@@ -106,7 +106,7 @@ class Solution(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Solution/Interrupt',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Solution/Interrupt',
             solution__pb2.InterruptRequest.SerializeToString,
             solution__pb2.InterruptResponse.FromString,
             options, channel_credentials,
@@ -122,7 +122,7 @@ class Solution(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/syc.Solution/Abort',
+        return grpc.experimental.unary_unary(request, target, '/ansys.api.systemcoupling.v0.Solution/Abort',
             solution__pb2.AbortRequest.SerializeToString,
             solution__pb2.AbortResponse.FromString,
             options, channel_credentials,

--- a/ansys/api/systemcoupling/v0/variant_pb2.py
+++ b/ansys/api/systemcoupling/v0/variant_pb2.py
@@ -16,16 +16,16 @@ _sym_db = _symbol_database.Default()
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='variant.proto',
-  package='syc',
+  package='ansys.api.systemcoupling.v0',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\rvariant.proto\x12\x03syc\"\x1c\n\x0cStringVector\x12\x0c\n\x04item\x18\x01 \x03(\t\"\x1c\n\x0c\x44oubleVector\x12\x0c\n\x04item\x18\x01 \x03(\x01\"\x1a\n\nBoolVector\x12\x0c\n\x04item\x18\x01 \x03(\x08\"\x1b\n\x0bInt64Vector\x12\x0c\n\x04item\x18\x01 \x03(\x12\"p\n\nVariantMap\x12\'\n\x04item\x18\x01 \x03(\x0b\x32\x19.syc.VariantMap.ItemEntry\x1a\x39\n\tItemEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x1b\n\x05value\x18\x02 \x01(\x0b\x32\x0c.syc.Variant:\x02\x38\x01\"+\n\rVariantVector\x12\x1a\n\x04item\x18\x01 \x03(\x0b\x32\x0c.syc.Variant\"\xb6\x03\n\x07Variant\x12$\n\nnone_state\x18\x01 \x01(\x0e\x32\x0e.syc.NoneValueH\x00\x12\x14\n\nbool_state\x18\x02 \x01(\x08H\x00\x12\x15\n\x0bint64_state\x18\x03 \x01(\x12H\x00\x12\x16\n\x0c\x64ouble_state\x18\x05 \x01(\x01H\x00\x12\x16\n\x0cstring_state\x18\x06 \x01(\tH\x00\x12,\n\x11\x62ool_vector_state\x18\x07 \x01(\x0b\x32\x0f.syc.BoolVectorH\x00\x12.\n\x12int64_vector_state\x18\x08 \x01(\x0b\x32\x10.syc.Int64VectorH\x00\x12\x30\n\x13\x64ouble_vector_state\x18\t \x01(\x0b\x32\x11.syc.DoubleVectorH\x00\x12\x30\n\x13string_vector_state\x18\n \x01(\x0b\x32\x11.syc.StringVectorH\x00\x12\x32\n\x14variant_vector_state\x18\x0b \x01(\x0b\x32\x12.syc.VariantVectorH\x00\x12,\n\x11variant_map_state\x18\x0c \x01(\x0b\x32\x0f.syc.VariantMapH\x00\x42\x04\n\x02\x61s*\x1b\n\tNoneValue\x12\x0e\n\nNONE_VALUE\x10\x00\x62\x06proto3'
+  serialized_pb=b'\n\rvariant.proto\x12\x1b\x61nsys.api.systemcoupling.v0\"\x1c\n\x0cStringVector\x12\x0c\n\x04item\x18\x01 \x03(\t\"\x1c\n\x0c\x44oubleVector\x12\x0c\n\x04item\x18\x01 \x03(\x01\"\x1a\n\nBoolVector\x12\x0c\n\x04item\x18\x01 \x03(\x08\"\x1b\n\x0bInt64Vector\x12\x0c\n\x04item\x18\x01 \x03(\x12\"\xa0\x01\n\nVariantMap\x12?\n\x04item\x18\x01 \x03(\x0b\x32\x31.ansys.api.systemcoupling.v0.VariantMap.ItemEntry\x1aQ\n\tItemEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x33\n\x05value\x18\x02 \x01(\x0b\x32$.ansys.api.systemcoupling.v0.Variant:\x02\x38\x01\"C\n\rVariantVector\x12\x32\n\x04item\x18\x01 \x03(\x0b\x32$.ansys.api.systemcoupling.v0.Variant\"\xde\x04\n\x07Variant\x12<\n\nnone_state\x18\x01 \x01(\x0e\x32&.ansys.api.systemcoupling.v0.NoneValueH\x00\x12\x14\n\nbool_state\x18\x02 \x01(\x08H\x00\x12\x15\n\x0bint64_state\x18\x03 \x01(\x12H\x00\x12\x16\n\x0c\x64ouble_state\x18\x05 \x01(\x01H\x00\x12\x16\n\x0cstring_state\x18\x06 \x01(\tH\x00\x12\x44\n\x11\x62ool_vector_state\x18\x07 \x01(\x0b\x32\'.ansys.api.systemcoupling.v0.BoolVectorH\x00\x12\x46\n\x12int64_vector_state\x18\x08 \x01(\x0b\x32(.ansys.api.systemcoupling.v0.Int64VectorH\x00\x12H\n\x13\x64ouble_vector_state\x18\t \x01(\x0b\x32).ansys.api.systemcoupling.v0.DoubleVectorH\x00\x12H\n\x13string_vector_state\x18\n \x01(\x0b\x32).ansys.api.systemcoupling.v0.StringVectorH\x00\x12J\n\x14variant_vector_state\x18\x0b \x01(\x0b\x32*.ansys.api.systemcoupling.v0.VariantVectorH\x00\x12\x44\n\x11variant_map_state\x18\x0c \x01(\x0b\x32\'.ansys.api.systemcoupling.v0.VariantMapH\x00\x42\x04\n\x02\x61s*\x1b\n\tNoneValue\x12\x0e\n\nNONE_VALUE\x10\x00\x62\x06proto3'
 )
 
 _NONEVALUE = _descriptor.EnumDescriptor(
   name='NoneValue',
-  full_name='syc.NoneValue',
+  full_name='ansys.api.systemcoupling.v0.NoneValue',
   filename=None,
   file=DESCRIPTOR,
   create_key=_descriptor._internal_create_key,
@@ -38,8 +38,8 @@ _NONEVALUE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=739,
-  serialized_end=766,
+  serialized_start=1004,
+  serialized_end=1031,
 )
 _sym_db.RegisterEnumDescriptor(_NONEVALUE)
 
@@ -50,14 +50,14 @@ NONE_VALUE = 0
 
 _STRINGVECTOR = _descriptor.Descriptor(
   name='StringVector',
-  full_name='syc.StringVector',
+  full_name='ansys.api.systemcoupling.v0.StringVector',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.StringVector.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.StringVector.item', index=0,
       number=1, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -75,21 +75,21 @@ _STRINGVECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=22,
-  serialized_end=50,
+  serialized_start=46,
+  serialized_end=74,
 )
 
 
 _DOUBLEVECTOR = _descriptor.Descriptor(
   name='DoubleVector',
-  full_name='syc.DoubleVector',
+  full_name='ansys.api.systemcoupling.v0.DoubleVector',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.DoubleVector.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.DoubleVector.item', index=0,
       number=1, type=1, cpp_type=5, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -107,21 +107,21 @@ _DOUBLEVECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=52,
-  serialized_end=80,
+  serialized_start=76,
+  serialized_end=104,
 )
 
 
 _BOOLVECTOR = _descriptor.Descriptor(
   name='BoolVector',
-  full_name='syc.BoolVector',
+  full_name='ansys.api.systemcoupling.v0.BoolVector',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.BoolVector.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.BoolVector.item', index=0,
       number=1, type=8, cpp_type=7, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -139,21 +139,21 @@ _BOOLVECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=82,
-  serialized_end=108,
+  serialized_start=106,
+  serialized_end=132,
 )
 
 
 _INT64VECTOR = _descriptor.Descriptor(
   name='Int64Vector',
-  full_name='syc.Int64Vector',
+  full_name='ansys.api.systemcoupling.v0.Int64Vector',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.Int64Vector.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.Int64Vector.item', index=0,
       number=1, type=18, cpp_type=2, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -171,28 +171,28 @@ _INT64VECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=110,
-  serialized_end=137,
+  serialized_start=134,
+  serialized_end=161,
 )
 
 
 _VARIANTMAP_ITEMENTRY = _descriptor.Descriptor(
   name='ItemEntry',
-  full_name='syc.VariantMap.ItemEntry',
+  full_name='ansys.api.systemcoupling.v0.VariantMap.ItemEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='syc.VariantMap.ItemEntry.key', index=0,
+      name='key', full_name='ansys.api.systemcoupling.v0.VariantMap.ItemEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='value', full_name='syc.VariantMap.ItemEntry.value', index=1,
+      name='value', full_name='ansys.api.systemcoupling.v0.VariantMap.ItemEntry.value', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -210,20 +210,20 @@ _VARIANTMAP_ITEMENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=194,
-  serialized_end=251,
+  serialized_start=243,
+  serialized_end=324,
 )
 
 _VARIANTMAP = _descriptor.Descriptor(
   name='VariantMap',
-  full_name='syc.VariantMap',
+  full_name='ansys.api.systemcoupling.v0.VariantMap',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.VariantMap.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.VariantMap.item', index=0,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -241,21 +241,21 @@ _VARIANTMAP = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=139,
-  serialized_end=251,
+  serialized_start=164,
+  serialized_end=324,
 )
 
 
 _VARIANTVECTOR = _descriptor.Descriptor(
   name='VariantVector',
-  full_name='syc.VariantVector',
+  full_name='ansys.api.systemcoupling.v0.VariantVector',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='item', full_name='syc.VariantVector.item', index=0,
+      name='item', full_name='ansys.api.systemcoupling.v0.VariantVector.item', index=0,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -273,91 +273,91 @@ _VARIANTVECTOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=253,
-  serialized_end=296,
+  serialized_start=326,
+  serialized_end=393,
 )
 
 
 _VARIANT = _descriptor.Descriptor(
   name='Variant',
-  full_name='syc.Variant',
+  full_name='ansys.api.systemcoupling.v0.Variant',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='none_state', full_name='syc.Variant.none_state', index=0,
+      name='none_state', full_name='ansys.api.systemcoupling.v0.Variant.none_state', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='bool_state', full_name='syc.Variant.bool_state', index=1,
+      name='bool_state', full_name='ansys.api.systemcoupling.v0.Variant.bool_state', index=1,
       number=2, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='int64_state', full_name='syc.Variant.int64_state', index=2,
+      name='int64_state', full_name='ansys.api.systemcoupling.v0.Variant.int64_state', index=2,
       number=3, type=18, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='double_state', full_name='syc.Variant.double_state', index=3,
+      name='double_state', full_name='ansys.api.systemcoupling.v0.Variant.double_state', index=3,
       number=5, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='string_state', full_name='syc.Variant.string_state', index=4,
+      name='string_state', full_name='ansys.api.systemcoupling.v0.Variant.string_state', index=4,
       number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='bool_vector_state', full_name='syc.Variant.bool_vector_state', index=5,
+      name='bool_vector_state', full_name='ansys.api.systemcoupling.v0.Variant.bool_vector_state', index=5,
       number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='int64_vector_state', full_name='syc.Variant.int64_vector_state', index=6,
+      name='int64_vector_state', full_name='ansys.api.systemcoupling.v0.Variant.int64_vector_state', index=6,
       number=8, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='double_vector_state', full_name='syc.Variant.double_vector_state', index=7,
+      name='double_vector_state', full_name='ansys.api.systemcoupling.v0.Variant.double_vector_state', index=7,
       number=9, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='string_vector_state', full_name='syc.Variant.string_vector_state', index=8,
+      name='string_vector_state', full_name='ansys.api.systemcoupling.v0.Variant.string_vector_state', index=8,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='variant_vector_state', full_name='syc.Variant.variant_vector_state', index=9,
+      name='variant_vector_state', full_name='ansys.api.systemcoupling.v0.Variant.variant_vector_state', index=9,
       number=11, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='variant_map_state', full_name='syc.Variant.variant_map_state', index=10,
+      name='variant_map_state', full_name='ansys.api.systemcoupling.v0.Variant.variant_map_state', index=10,
       number=12, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -375,13 +375,13 @@ _VARIANT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='as', full_name='syc.Variant.as',
+      name='as', full_name='ansys.api.systemcoupling.v0.Variant.as',
       index=0, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=299,
-  serialized_end=737,
+  serialized_start=396,
+  serialized_end=1002,
 )
 
 _VARIANTMAP_ITEMENTRY.fields_by_name['value'].message_type = _VARIANT
@@ -441,28 +441,28 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 StringVector = _reflection.GeneratedProtocolMessageType('StringVector', (_message.Message,), {
   'DESCRIPTOR' : _STRINGVECTOR,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.StringVector)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.StringVector)
   })
 _sym_db.RegisterMessage(StringVector)
 
 DoubleVector = _reflection.GeneratedProtocolMessageType('DoubleVector', (_message.Message,), {
   'DESCRIPTOR' : _DOUBLEVECTOR,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.DoubleVector)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.DoubleVector)
   })
 _sym_db.RegisterMessage(DoubleVector)
 
 BoolVector = _reflection.GeneratedProtocolMessageType('BoolVector', (_message.Message,), {
   'DESCRIPTOR' : _BOOLVECTOR,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.BoolVector)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.BoolVector)
   })
 _sym_db.RegisterMessage(BoolVector)
 
 Int64Vector = _reflection.GeneratedProtocolMessageType('Int64Vector', (_message.Message,), {
   'DESCRIPTOR' : _INT64VECTOR,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.Int64Vector)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.Int64Vector)
   })
 _sym_db.RegisterMessage(Int64Vector)
 
@@ -471,12 +471,12 @@ VariantMap = _reflection.GeneratedProtocolMessageType('VariantMap', (_message.Me
   'ItemEntry' : _reflection.GeneratedProtocolMessageType('ItemEntry', (_message.Message,), {
     'DESCRIPTOR' : _VARIANTMAP_ITEMENTRY,
     '__module__' : 'variant_pb2'
-    # @@protoc_insertion_point(class_scope:syc.VariantMap.ItemEntry)
+    # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.VariantMap.ItemEntry)
     })
   ,
   'DESCRIPTOR' : _VARIANTMAP,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.VariantMap)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.VariantMap)
   })
 _sym_db.RegisterMessage(VariantMap)
 _sym_db.RegisterMessage(VariantMap.ItemEntry)
@@ -484,14 +484,14 @@ _sym_db.RegisterMessage(VariantMap.ItemEntry)
 VariantVector = _reflection.GeneratedProtocolMessageType('VariantVector', (_message.Message,), {
   'DESCRIPTOR' : _VARIANTVECTOR,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.VariantVector)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.VariantVector)
   })
 _sym_db.RegisterMessage(VariantVector)
 
 Variant = _reflection.GeneratedProtocolMessageType('Variant', (_message.Message,), {
   'DESCRIPTOR' : _VARIANT,
   '__module__' : 'variant_pb2'
-  # @@protoc_insertion_point(class_scope:syc.Variant)
+  # @@protoc_insertion_point(class_scope:ansys.api.systemcoupling.v0.Variant)
   })
 _sym_db.RegisterMessage(Variant)
 

--- a/protos/ansys/api/systemcoupling/v0/command.proto
+++ b/protos/ansys/api/systemcoupling/v0/command.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 import "variant.proto";
 
@@ -11,12 +11,12 @@ service Command {
 message CommandRequest {
   message Argument {
     string name = 1;
-    syc.Variant val = 2;
+    Variant val = 2;
   }
   string command = 1;
   repeated Argument args = 2;
 }
 
 message CommandResponse {
-  syc.Variant result = 1;
+  Variant result = 1;
 }

--- a/protos/ansys/api/systemcoupling/v0/error.proto
+++ b/protos/ansys/api/systemcoupling/v0/error.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 message ErrorDetails {
   string exception_classname = 1;

--- a/protos/ansys/api/systemcoupling/v0/output_stream.proto
+++ b/protos/ansys/api/systemcoupling/v0/output_stream.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 service OutputStream {
   rpc BeginStdStreaming(StdStreamRequest) returns (stream StdStreamResponse) {}

--- a/protos/ansys/api/systemcoupling/v0/process.proto
+++ b/protos/ansys/api/systemcoupling/v0/process.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 service Process {
   rpc Ping (PingRequest) returns (PingResponse) {}

--- a/protos/ansys/api/systemcoupling/v0/solution.proto
+++ b/protos/ansys/api/systemcoupling/v0/solution.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 service Solution {
   rpc Solve (SolveRequest) returns (SolveResponse) {}

--- a/protos/ansys/api/systemcoupling/v0/variant.proto
+++ b/protos/ansys/api/systemcoupling/v0/variant.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syc;
+package ansys.api.systemcoupling.v0;
 
 enum NoneValue {
   NONE_VALUE=0;


### PR DESCRIPTION
PySyC defines a 'variant' proto that was originally derived from one used in Fluent and retained the `utils` package name that had been adopted for Fluent. All other SyC protos are simply in the `syc` package.

When an attempt was made to import both pySystemCoupling and pyFluent (in either order) an exception was seen because of duplicate proto-derived types.

The original fix was simply to change the package name for the variant to be `syc` but it was pointed out to me that we should be following the standard proto package naming conventions to match the `ansys.api.<product>.v<#>` Python package/directory structure.

Note that the SyC server needs a rebuild too so there might be a period where the pysystem-coupling client and the server are out of sync, depending on which version of each is being used.