### PR TITLE
missing change from previous PR

### DIFF
--- a/requirements/requirements_classesgen.txt
+++ b/requirements/requirements_classesgen.txt
@@ -8,5 +8,5 @@
 # in sync with the pre-commit config.
 black==22.3.0
 isort==5.10.1
-pyyaml
+
 


### PR DESCRIPTION
A file change got missed in previous PR #23 because of the file location being moved.

The change is just a minor tidy up and has no effect in practice as it is removes unnecessary pyyaml dependency from venv requirements. This is already included in pysystem-coupling package so no need to include it again.