### PR TITLE
Add "mock solver" unit test

### DIFF
--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -1,5 +1,8 @@
 import subprocess
 
+_MPI_VERSION_VAR = "FLUENT_INTEL_MPI_VERSION"
+_MPI_VERSION = "2021"
+
 
 def start_container(port: int) -> None:
     """Start a System Coupling container.
@@ -21,6 +24,8 @@ def start_container(port: int) -> None:
             f"{port}:{port}",
             # "-v",
             # f"{mounted_from}:{mounted_to}",
+            "-e",
+            f"{_MPI_VERSION_VAR}={_MPI_VERSION}",
             "ghcr.io/pyansys/pysystem-coupling",
         ]
         + args

--- a/tests/test_mocksolve_container.py
+++ b/tests/test_mocksolve_container.py
@@ -1,0 +1,81 @@
+import ansys.systemcoupling.core as pysystemcoupling
+
+
+def test_partlib_cosim_volume_simple() -> None:
+    """Equivalent of SyC test partlib-cosim-volume-simple.
+
+    One of the simplest examples using a mock solver.
+    """
+
+    with pysystemcoupling.launch_container() as syc:
+        assert syc.ping()
+
+        setup = syc.setup
+        p1 = setup.add_participant(
+            executable=_get_mocksolve_executable(), additional_arguments="--p1"
+        )
+        p2 = setup.add_participant(
+            executable=_get_mocksolve_executable(), additional_arguments="--p2"
+        )
+        interface = setup.add_interface(
+            side_one_participant=p1,
+            side_one_regions=["volume"],
+            side_two_participant=p2,
+            side_two_regions=["volume"],
+        )
+
+        dt1 = setup.add_data_transfer(
+            interface=interface,
+            target_side="Two",
+            side_one_variable="p1_to_p2",
+            side_two_variable="p1_to_p2",
+        )
+
+        dt2 = setup.add_data_transfer(
+            interface=interface,
+            target_side="One",
+            side_one_variable="p2_to_p1",
+            side_two_variable="p2_to_p1",
+        )
+
+        output_handler = _OutputHandler()
+        syc.start_output(handle_output=output_handler.on_line)
+
+        solution = syc.solution
+        solution.solve()
+
+        syc._native_api.PrintState(ObjectPath="/SystemCoupling/OutputControl")
+        syc.end_output()
+
+        assert any(
+            "        Shut Down         " in line for line in output_handler.lines
+        )
+
+
+def _get_mocksolve_executable():
+
+    # System Coupling is packaged under /syc in the image
+
+    # Note that we don't use os.path.join here because it
+    # would give us a Windows path on Windows and we always
+    # want a unix-style path.
+
+    return "/" + "/".join(
+        (
+            "syc",
+            "SystemCoupling",
+            "Tests",
+            "SystemCouplingParticipant",
+            "TestSolvers",
+            "Python",
+            "VolumeCosimTester.sh",
+        )
+    )
+
+
+class _OutputHandler:
+    def __init__(self):
+        self.lines = []
+
+    def on_line(self, line):
+        self.lines.append(line)


### PR DESCRIPTION
Add a PySystemCoupling version of one of the System Coupling regression tests that uses a "mock solver" as a participant.

In the System Coupling context, this is a useful test of coupling infrastructure without depending on external products. In the PySystemCoupling unit testing context, we currently _cannot_ depend on external products but this test allows us to gain some extra coverage, such as being able to use the `solve` command in a test. 

It also exercises an aspect of the System Coupling Docker container that previously was not working. Anything that involved starting up the MPI compute nodes was failing. It has come to light that we needed to start the container with an environment variable that controls the MPI version used by Multiport. This fix has been implemented in the container launch function.