### PR TITLE
Support additional launch options and add some flexibility for other startup options

### DIFF
--- a/src/ansys/systemcoupling/core/__init__.py
+++ b/src/ansys/systemcoupling/core/__init__.py
@@ -1,10 +1,19 @@
+from typing import List
+
 from ansys.systemcoupling.core._version import __version__
 from ansys.systemcoupling.core.client.grpc_client import SycGrpc
 from ansys.systemcoupling.core.session import Session
 from ansys.systemcoupling.core.util.logging import LOG
 
 
-def launch(port: int = None, working_dir: str = None):
+def launch(
+    *,
+    port: int = None,
+    working_dir: str = None,
+    nprocs: int = None,
+    sycnprocs: int = None,
+    extra_args: List[str] = []
+) -> Session:
     """Start a local instance of System Coupling and connects to it.
 
     Parameters
@@ -17,6 +26,23 @@ def launch(port: int = None, working_dir: str = None):
         The working directory of the System Coupling process. Defaults to
         the current directory of the client process.
 
+    nprocs : int, optional
+        The number of processes for coupling participants. If not provided,
+        the System Coupling server will use its own default.
+
+    sycnprocs : int, optional
+        The number of processes for the coupling engine. If not provided,
+        the System Coupling server will use its own default.
+
+    extra_args : List[str]
+        List of any additional arguments to be specified when the server
+        process is launched. Defaults to empty list.
+
+        If provided, this is concatenated as-is to the list of
+        arguments already being passed when the process is started. If
+        an argument has an associated value, the argument name and its
+        value should be specified as two consecutive items of the list.
+
     Returns
     -------
     ansys.systemcoupling.core.session.Session
@@ -24,7 +50,13 @@ def launch(port: int = None, working_dir: str = None):
         remote System Coupling instance.
     """
     rpc = SycGrpc()
-    rpc.start_and_connect(port, working_dir)
+    rpc.start_and_connect(
+        port=port,
+        working_dir=working_dir,
+        nprocs=nprocs,
+        sycnprocs=sycnprocs,
+        extra_args=extra_args,
+    )
     syc = Session(rpc)
     return syc
 

--- a/src/ansys/systemcoupling/core/client/grpc_client.py
+++ b/src/ansys/systemcoupling/core/client/grpc_client.py
@@ -77,13 +77,16 @@ class SycGrpc(object):
         for instance in list(cls._instances.values()):
             instance.exit()
 
-    def start_and_connect(self, port, working_dir):
+    def start_and_connect(self, **kwargs):
         """Start system coupling in server mode and establish a connection."""
 
         # Support backdoor container launch via env var.
         # For example we might want to default to launching installation
         # locally but container on GitHub (e.g. for build tasks like code generation).
         # Can still switch to container locally by setting variable.
+
+        working_dir = kwargs.pop("working_dir", None)
+        port = kwargs.pop("port", None)
 
         if os.environ.get("SYC_LAUNCH_CONTAINER") == "1":
             if working_dir is not None:
@@ -97,7 +100,7 @@ class SycGrpc(object):
             if working_dir is None:
                 working_dir = "."
             LOG.debug("Starting process...")
-            self.__process = SycProcess(_LOCALHOST_IP, port, working_dir)
+            self.__process = SycProcess(_LOCALHOST_IP, port, working_dir, **kwargs)
             LOG.debug("...started")
             self._connect(_LOCALHOST_IP, port)
 


### PR DESCRIPTION
The current command line options used to launch the SyC process are pretty concrete and limited. It is not possible to specify number of SyC or participant processes for example.

Explicit launch options `nprocs` and `sycnprocs` have been added as arguments to the `launch()` function. These correspond to the SyC options and are the additional options most likely to be needed.

In addition a generic `extra_args` list may now be specified. This provides the flexibility to pass any valid command line options to the SyC process launch. Over time, we might promote some more arguments to be explicitly supported in the `launch()` signature as we have done with `nprocs` and `sycnprocs`.