### PR TITLE
Add 'protobuf' to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - "dependencies"
     ignore:
       - dependency-name: "grpcio"
+      - dependency-name: "protobuf"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Recent ``dependabot`` run wanted to bump the max version of ``protobuf`` to be > 4, but we currently have a hard constraint of < 4 because of widespread compatibility issues. Adding ``protobuf`` to the ignore list so that ``dependabot`` does not try this again.