### PR TITLE
Add doc/styles/.gitignore

### DIFF
--- a/doc/styles/.gitignore
+++ b/doc/styles/.gitignore
@@ -1,0 +1,4 @@
+*
+!Vocab
+!Vocab/**
+!.gitignore


### PR DESCRIPTION
Missed this the other day when doc style checking was introduced. Idea of the `.gitignore` is that we want to allow styles (such as Google) to be installed locally but we don't want to commit them as they are always installed as part of the GitHub action.

@anskfletcher FYI