### PR TITLE
Reintroduce pyansys/actions/build-library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ readme = "README.rst"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}
 authors = [
-    {name = "Ansys, Inc.", email = "pyansys.support@ansys.com"},
+    {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
 ]
 maintainers = [
-    {name = "PyAnsys developers", email = "pyansys.support@ansys.com"},
+    {name = "PyAnsys developers", email = "pyansys.maintainers@ansys.com"},
 ]
 dependencies = [
 	"grpcio>=1.30.0",


### PR DESCRIPTION
An initial attempt to use the `build-library` action failed because it was not including the generated API code. This was despite the steps in the action implementation looking very similar to the explicit steps in the working workflow. The issue was found to be that the "checkout" step needs to be disabled in the action, otherwise the checkout clears the generated code.