### PR TITLE
Doc for 'NativeApi' class was not being generated.

### DIFF
--- a/doc/source/api/core/adaptor/native_api_class.rst
+++ b/doc/source/api/core/adaptor/native_api_class.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+.. _ref_native_api_class:
+
+``NativeApi``
+=============
+
+.. autoclass:: ansys.systemcoupling.core.native_api.NativeApi
+    :members:
+    :special-members: __getattr__

--- a/doc/source/api/core/adaptor/native_api_property.rst
+++ b/doc/source/api/core/adaptor/native_api_property.rst
@@ -6,3 +6,4 @@
 =======================
 
 .. autoproperty:: ansys.systemcoupling.core.session.Session._native_api
+

--- a/doc/source/api/core/session.rst
+++ b/doc/source/api/core/session.rst
@@ -11,4 +11,5 @@ Session
     session.Session
 
 The ``Session`` class also exposes a `quasi-private` property to access
-the System Coupling `native API` directly. See :ref:`ref_native_api_property` for details.
+the System Coupling `native API` directly. See :ref:`ref_native_api_property`
+and  :ref:`ref_native_api_class` for details.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -37,7 +37,7 @@ after the preceding installation steps.
 
 .. code::
 
-    pip install .[classesgen]
+    pip install -e .[classesgen]
     python scripts/generate_datamodel.py
 
 The generated code is written to a directory ``src/ansys/systemcoupling/core/adaptor/api_<version>``,
@@ -67,7 +67,7 @@ With this variable set, execute the following commands:
 
 .. code::
 
-    pip install .[doc]
+    pip install -e .[doc]
     cd doc
     make html
 

--- a/src/ansys/systemcoupling/core/session.py
+++ b/src/ansys/systemcoupling/core/session.py
@@ -100,7 +100,7 @@ class Session:
         Python console environments. In such cases, a custom approach based
         on the handler might be preferred.
 
-        Streaming can be cancelled by calling the ``end_output`` method.
+        Streaming can be cancelled by calling the `end_output` method.
 
         Parameters
         ----------
@@ -113,7 +113,7 @@ class Session:
         self.__rpc.start_output(handle_output)
 
     def end_output(self) -> None:
-        """Cancels output streaming previously started by ``start_output``."""
+        """Cancels output streaming previously started by `start_output`."""
         self.__rpc.end_output()
 
     def ping(self) -> bool:
@@ -162,7 +162,7 @@ class Session:
 
     @property
     def _native_api(self) -> NativeApi:
-        """Provides access to the 'native' System Coupling API and data
+        """Provides access to the "native" System Coupling API and data
         model.
 
         Use of this API is not particularly encouraged but there may be
@@ -176,7 +176,7 @@ class Session:
         This API is exposed dynamically on the client side and provides
         little runtime assistance and documentation.
 
-        See the ``NativeApi`` class itself for more details.
+        See the `NativeApi` class itself for more details.
         """
         if self.__native_api is None:
             self.__native_api = NativeApi(self.__rpc)


### PR DESCRIPTION
`NativeApi` is accessed through an attribute, `_native_api` of ``Session``. The leading underscore being deliberate as we want to make it available but we don't want to encourage its use or draw too much attention to it.  Because of this naming, Sphinx doesn't automatically document it, and we have had to do some special things to get the doc to be shown and linked to. Doc for the `_native_api` attribute was already being generated, but not for for the class `NativeApi`, so this is fixed here. Also tidied up the doc comments for `NativeApi`.