### PR TITLE
Fix main CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,15 @@
 # Contributing
 
-Repositories should have a contributing section, but we don't need to have all the contributing information here.  Have them reference the developer guide.
-
 We absolutely welcome any code contributions and we hope that this
-guide will facilitate an understanding of the TEMPLATE code
-repository. It is important to note that while the TEMPLATE software
+guide will facilitate an understanding of the PySystemCoupling code
+repository. It is important to note that while the PySystemCoupling software
 package is maintained by ANSYS and any submissions will be reviewed
 thoroughly before merging, we still seek to foster a community that can
 support user questions and develop new features to make this software
 a useful tool for all users.  As such, we welcome and encourage any
 questions or submissions to this repository.
 
-Please reference the [PyAnsys Developer's
-Guide](https://github.com/pyansys/about) for the full documentation
-regarding contributing to the TEMPLATE project.
+For contributing to this project, please refer to the [PyAnsys Developer's
+Guide](https://dev.docs.pyansys.com/). Further information about
+contributing to PySystemCoupling can be found in
+[Contributing](https://systemcoupling.docs.pyansys.com/dev/contributing.html).


### PR DESCRIPTION
The `CONTRIBUTING.md`was still in its old default state from the original template.

Updated to match the form of the PyMAPDL one (which was not vastly different from the template in any case).