### PR TITLE
MAINT: downgrade Sphinx to 5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ doc = [
 	"numpydoc==1.5.0",
 	"pypandoc==1.10",
 	"pytest-sphinx==0.5.0",
-	"Sphinx==6.1.3",
+	"Sphinx==5.3.0",
 	"sphinx-autobuild==2021.3.14",
 	"sphinx-autodoc-typehints==1.21.1",
 	"sphinx-copybutton==0.5.1",


### PR DESCRIPTION
The latest Sphinx version introduced some buggy behavior in the form of a unknown icon in the top navigation bar of our theme, see:

![bug](https://user-images.githubusercontent.com/28702884/213371912-5f9cdbb2-80c7-4712-b389-2d1960328d69.png)

For the moment, we are downgrading Sphinx versions to 5.3.0.