### PR TITLE
Standardizing Windows data path

### DIFF
--- a/src/ansys/systemcoupling/core/__init__.py
+++ b/src/ansys/systemcoupling/core/__init__.py
@@ -110,16 +110,14 @@ def connect(host: str, port: int) -> Session:  # pragma: no cover
 
 
 # Set up data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir("ansys_systemcoupling_core")
-    if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-        os.makedirs(USER_DATA_PATH)
+USER_DATA_PATH = appdirs.user_data_dir(
+    appname="ansys_systemcoupling_core", appauthor="Ansys"
+)
+if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
+    os.makedirs(USER_DATA_PATH)
 
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-        os.makedirs(EXAMPLES_PATH)
-
-except:  # pragma: no cover
-    pass
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
+if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
+    os.makedirs(EXAMPLES_PATH)
 
 BUILDING_GALLERY = False


### PR DESCRIPTION
Minor change when running on Windows: from `USER_DATA_PATH` resolving to `%LocalAppData%\ansys_systemcoupling_core\ansys_systemcoupling_core`, changed to `%LocalAppData%\Ansys\ansys_systemcoupling_core` using the same root folder `%LocalAppData%\Ansys` as other applications. No change on Linux, resolves to `~/.local/share/ansys_systemcoupling_core`.

Original issue tracker https://github.com/ansys/pyfluent/issues/1588

Same Windows data path naming scheme as in https://github.com/ansys/pyfluent/pull/1615, https://github.com/ansys/pymapdl/pull/2064, https://github.com/ansys/pyprimemesh/pull/485, https://github.com/ansys/ansys-tools-path/pull/44

Also removed try-except block

Food for thought: data path and examples folders are immediately created when `import ansys.systemcoupling.core`, might be worth changing to create folders only when/if they are actually used