### PR TITLE
Ignore some tokens that are giving spurious errors in vale

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -27,6 +27,8 @@ Vocab = ANSYS
 # Apply the following styles
 BasedOnStyles = Vale, Google
 
+TokenIgnores = (:(func|class|meth|attr|py):`(?:.|\n)*?`)|(<.*>)|(.. code::.*\n| .*)
+
 # Removing Google-specific rule - Not applicable under some circumstances
 Google.Colons = NO
 Google.Quotes = NO


### PR DESCRIPTION
We are seeing vale errors appearing in current PRs. They appear to be spurious complaints about substrings such as `"n.S"` missing a space. Presumably these are being interpreted as end of sentences, with a full stop, whereas in fact these substrings come from Python paths to modules, classes, etc.

See MAPDL #2394 where the fix is applied there to solve similar errors.
