### PR TITLE
Try to fix recent build failure - possibly arising from action upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
 
 
       - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: documentation-html
           path: doc/_build/html
@@ -210,7 +210,7 @@ jobs:
 
 
       - name: Upload PDF Documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: documentation-pdf
           path: doc/_build/latex/*.pdf

--- a/tests/test_mocksolve_container.py
+++ b/tests/test_mocksolve_container.py
@@ -26,7 +26,7 @@ def test_partlib_cosim_volume_simple() -> None:
 
         messages = setup.get_status_messages()
 
-        assert len(messages) == 1
+        assert len(messages) == 1, print(messages)
         assert messages[0]["path"] == 'coupling_interface["Interface-1"]'
         assert messages[0]["message"].startswith(
             "No data transfers exist on Interface-1"


### PR DESCRIPTION
The issue is that the `doc-deploy-dev` action is failing, saying it can't find the "documentation-html" artifact. This artifact does appear to be present in the build. Prior to this, the documentation upload action `upload-artifact` was upgraded via a dependabot PR. Therefore trying a revert here, downgrading `upload-artifact` back to 3 from 4.

Note that the documentation deployment action only happens on a merge to `main` so this was not detected immediately. Furthermore the upstream _doc build_ task failed when the `upload-artifact` PR was initially merged to `main`, which further hid the issue.
