### PR TITLE
Update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Exclusions
-exclude: ^(examples/|doc/)
+exclude: ^(doc/source/examples)
 
 # initially copied from pymapdl
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,8 @@ repos:
   hooks:
   - id: black
 
-- repo: https://github.com/asottile/blacken-docs
-  rev: v1.12.1
+- repo: https://github.com/adamchainz/blacken-docs
+  rev: 1.16.0
   hooks:
   -   id: blacken-docs
       additional_dependencies: [black==24.1.0]
@@ -20,12 +20,12 @@ repos:
   - id: isort
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.0.0
   hooks:
   - id: flake8
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.2
+  rev: v2.2.6
   hooks:
   - id: codespell
     args: ["--ignore-words", "doc/styles/Vocab/ANSYS/accept.txt"]
@@ -40,6 +40,6 @@ repos:
 
 # validate GitHub workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.21.0
+  rev: 0.27.3
   hooks:
     - id: check-github-workflows

--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -30,7 +30,9 @@ import os
 # PYSYC_DOC_BUILD_VERSION should contain a string such as "23_2" that determines the
 # System Coupling version the API is generated for and which we are building doc for.
 # This should be the only place in this script where we depend on the version.
-api_path = f"ansys.systemcoupling.core.adaptor.api_{os.environ['PYSYC_DOC_BUILD_VERSION']}"
+api_path = (
+    f"ansys.systemcoupling.core.adaptor.api_{os.environ['PYSYC_DOC_BUILD_VERSION']}"
+)
 case_root = importlib.import_module(f"{api_path}.case_root")
 setup_root = importlib.import_module(f"{api_path}.setup_root")
 solution_root = importlib.import_module(f"{api_path}.solution_root")
@@ -73,8 +75,9 @@ def _generate_property_list_for_rst(r, data_dict={}):
             # relative to first. Could be addressed by manually splitting first doc
             # line perhaps?
             inferred_indent = min(
-                (_find_indent(line) for line in lines[1:] if line.strip() != ""), default=0
-                )
+                (_find_indent(line) for line in lines[1:] if line.strip() != ""),
+                default=0,
+            )
             lines = [lines[0]] + [line[inferred_indent:] for line in lines[1:]]
 
         doc = indent + (f"\n{indent}".join(lines))
@@ -182,9 +185,7 @@ def _populate_rst_from_settings(rst_dir, cls):
         #    title = "Case and Persistence Commands"
         r.write(f"{title}\n")
         r.write(f'{"="*(len(title))}\n\n')
-        r.write(
-            f".. currentmodule:: {api_path}.{file_name}\n\n"
-        )
+        r.write(f".. currentmodule:: {api_path}.{file_name}\n\n")
         r.write(f".. autoclass:: {cls_name}\n")
         r.write(f"{istr1}:show-inheritance:\n")
         r.write(f"{istr1}:undoc-members:\n")

--- a/doc/datamodel_rstgen.py
+++ b/doc/datamodel_rstgen.py
@@ -24,6 +24,7 @@ Usage
 -----
 python <path to datamodel_rstgen.py>
 """
+
 import importlib
 import os
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,5 @@
 """Sphinx documentation configuration file."""
+
 from datetime import datetime
 import os
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,10 +1,17 @@
 """Sphinx documentation configuration file."""
+from datetime import datetime
 import os
 
-from datetime import datetime
-
+from ansys_sphinx_theme import (
+    ansys_favicon,
+    ansys_logo_white,
+    ansys_logo_white_cropped,
+    get_version_match,
+    latex,
+    pyansys_logo_black,
+    watermark,
+)
 import sphinx_gallery
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black, latex, ansys_logo_white, ansys_logo_white_cropped,get_version_match, watermark
 from sphinx_gallery.sorting import FileNameSortKey
 
 from ansys.systemcoupling.core import __version__
@@ -41,7 +48,7 @@ html_theme_options = {
     "switcher": {
         "json_url": f"https://{cname}/versions.json",
         "version_match": get_version_match(__version__),
-    }
+    },
 }
 
 # Sphinx extensions
@@ -53,7 +60,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",
     "sphinxemoji.sphinxemoji",
-    "sphinx_gallery.gen_gallery"
+    "sphinx_gallery.gen_gallery",
 ]
 
 # We can't build the gallery on GitHub as it requires full System Coupling
@@ -155,19 +162,27 @@ copybutton_prompt_is_regexp = True
 
 assert os.environ.get("PYSYC_DOC_BUILD_VERSION"), "PYSYC_DOC_BUILD_VERSION is not set!"
 
+
 def make_replacements_for_versioned_class_refs(names):
     # returns Sphinx "substitutions" of the form
     # .. |<NAME>_ROOT_CLASS_REF| replace:: :class:`<name>_root<..path to <name>_root module>`
 
-    api_path = f"ansys.systemcoupling.core.adaptor.api_{os.environ['PYSYC_DOC_BUILD_VERSION']}"
+    api_path = (
+        f"ansys.systemcoupling.core.adaptor.api_{os.environ['PYSYC_DOC_BUILD_VERSION']}"
+    )
 
     name_root = lambda n: f"{n.lower()}_root"
     make_subst_name = lambda n: f"{n.upper()}_ROOT_CLASS_REF"
-    make_class_ref = lambda n: f"{name_root(n)}<{api_path}.{name_root(n)}.{name_root(n)}>"
+    make_class_ref = (
+        lambda n: f"{name_root(n)}<{api_path}.{name_root(n)}.{name_root(n)}>"
+    )
 
-    make_subst = lambda n: f".. |{make_subst_name(n)}| replace:: :class:`{make_class_ref(n)}`"
+    make_subst = (
+        lambda n: f".. |{make_subst_name(n)}| replace:: :class:`{make_class_ref(n)}`"
+    )
 
     return "\n".join(make_subst(n) for n in names)
+
 
 rst_epilog = make_replacements_for_versioned_class_refs(("CASE", "SETUP", "SOLUTION"))
 
@@ -191,7 +206,7 @@ sphinx_gallery_conf = {
     "thumbnail_size": (350, 350),
     # "reset_modules_order": "after",
     # "reset_modules": (_stop_fluent_container),
-    #"plot_gallery": False,
+    # "plot_gallery": False,
     # Suppress config comments like "sphinx_gallery_thumbnail_path" from being rendered
     "remove_config_comments": True,
 }

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -61,6 +61,7 @@ Launch System Coupling from Python using the ``launch()`` function:
 .. code:: python
 
   import ansys.systemcoupling.core as pysystemcoupling
+
   syc = pysystemcoupling.launch()
   syc.ping()
 

--- a/doc/source/users_guide/analysis_setup.rst
+++ b/doc/source/users_guide/analysis_setup.rst
@@ -21,7 +21,7 @@ Set up participant cases
 Any participant that is involved in a coupled analysis must set up its case to solve its part of
 the coupled physics analysis. Typically, this is very similar to setting up a standalone case
 for this solver. Each participant has its own way of specifying data transfers to and from
-System Coupling. For example, Fluent uses fluid boundary conditions. 
+System Coupling. For example, Fluent uses fluid boundary conditions.
 
 While information on setting up participant cases is beyond the scope of this guide, you
 can see the System Coupling documentation for examples.
@@ -35,7 +35,7 @@ in the analysis.
 In its most common usage, this command accepts a file containing essential data about a participant,
 such as the variables it exposes and the regions on which they are available.
 
-.. code-block:: python
+.. code-block:: none
 
     >>> setup.add_participant(input_file="fluent.scp")
     'FLUENT-1'
@@ -61,7 +61,7 @@ adds Fluent and MAPDL participants, the ``analysis_control``, ``solution_control
 see the following output from the ``print_state`` command. Ellipses (``...``) appear where
 details are omitted from the output.
 
-.. code-block:: python
+.. code-block:: none
 
     >>> setup.print_state()
 
@@ -147,7 +147,7 @@ A value of ``<None>`` indicates an *unset* (missing) value.
    For example, the default for the ``analysis_control.global_stabilization.option``
    setting is ``"None"``. Thus, to avoid ambiguity, the ``print_state`` output
    displays ``<None>`` for unset values.
-   
+
    If queried in Python, an unset value holds the Python ``None`` object or an empty list
    (``[]``) for a setting whose value is a list.
 
@@ -184,7 +184,7 @@ This code shows how you use the ``add_interface`` command to add an interface to
         side_one_participant="MAPDL-2",
         side_one_regions=["FSIN_1"],
         side_two_participant="FLUENT-1",
-        side_two_regions=["wall_deforming"]
+        side_two_regions=["wall_deforming"],
     )
 
 The ``add_interface`` command returns the name of the interface created. This name
@@ -208,19 +208,19 @@ command.
         interface=interface_name,
         target_side="One",
         target_variable="FORC",
-        source_variable="force"
+        source_variable="force",
     )
 
     displacement_transfer_name = setup.add_data_transfer(
         interface=interface_name,
         target_side="Two",
         source_variable="INCD",
-        target_variable="displacement"
+        target_variable="displacement",
     )
 
 This code shows how you can examine the state of the resulting interface:
 
-.. code-block:: python
+.. code-block:: none
 
     >>> setup.coupling_interface[interface_name].print_state()
 
@@ -285,7 +285,7 @@ As shown in the following code, the return value of the ``get_status_messages`` 
 is a list of dictionaries, where each dictionary provides the details of a message. You
 can use the ``level`` field in a message dictionary to filter the message list:
 
-.. code-block:: python
+.. code-block:: none
 
 
     >>> from pprint import pprint

--- a/doc/source/users_guide/index.rst
+++ b/doc/source/users_guide/index.rst
@@ -119,9 +119,9 @@ cleaned up --- that is, ``exit`` called on it --- upon leaving the scope of the 
 .. code-block:: python
 
    with pysystemcoupling.launch() as syc_session:
-      # Use syc_session
-      ...
-      # No need to call syc_session.exit() at the end
+       # Use syc_session
+       ...
+       # No need to call syc_session.exit() at the end
 
    # syc_session has been exited at this point
 
@@ -138,6 +138,6 @@ filter and to specify whether logging goes to a file, to the console, or to both
    from ansys.systemcoupling.core import LOG
 
    ...
-   LOG.set_level("ERROR") # Log at level Error or more severe
+   LOG.set_level("ERROR")  # Log at level Error or more severe
    LOG.log_to_stdout()
 

--- a/doc/source/users_guide/syc_datamodel.rst
+++ b/doc/source/users_guide/syc_datamodel.rst
@@ -19,17 +19,17 @@ are named values of different value types, such as ``integer``, ``boolean``, and
   .. code-block:: none
     :emphasize-lines: 5,9,10
     :caption: System Coupling data model structure
-    
+
     root
       ├── participant
       │      ├── variable
       │      └── region
       ├── analysis_control
-      ├── coupling_interface   
+      ├── coupling_interface
       │      ├── side
       │      └── data_transfer
-      ├── solution_control   
-      └── output_control   
+      ├── solution_control
+      └── output_control
 
 
 In the image, highlighting distinguishes items representing objects at a level of the
@@ -38,9 +38,9 @@ hierarchy with only one *unnamed* instance versus multiple *named* instances:
 * Highlighted items represent objects for which only one unnamed instance can exist at this level
   (*singletons*).
 * Non-highlighted items represent objects for which multiple named instances can exist at this
-  level. 
-  
-  .. note:: 
+  level.
+
+  .. note::
     In general, object names can be freely chosen. The exception is the ``side`` object, for which exactly
     two instances exist. These two instances have fixed names: ``One`` and ``Two``.
 
@@ -98,7 +98,7 @@ data model, as shown in the following code examples.
 You can access unnamed objects, such as ``analysis_control`` attributes, even when
 they are initially *empty*. You can confirm this using the ``print_state()`` method:
 
-.. code-block:: python
+.. code-block:: none
 
 	>>> setup.analysis_control.print_state()
 
@@ -108,7 +108,7 @@ they are initially *empty*. You can confirm this using the ``print_state()`` met
 When you apply a setting to such an object, this not only sets a value for the specified
 setting but also sets the default values for other settings (where possible):
 
-.. code-block:: python
+.. code-block:: none
 
     >>> setup.analysis_control.analysis_type = "Steady"
     >>> setup.analysis_control.print_state()
@@ -125,7 +125,7 @@ setting but also sets the default values for other settings (where possible):
 To create a named object instance, use the ``create()`` method on the
 object's type attribute:
 
-.. code-block:: python
+.. code-block:: none
 
 	>>> setup.coupling_participant.create("Part1")
 	>>> setup.coupling_participant["Part1"].print_state()
@@ -147,7 +147,7 @@ object's type attribute:
 	>>>
 
 
-.. note::  
+.. note::
   The preceding code examples are for illustration only. A ``coupling_participant``
   object requires very specific data for it to be initialized in a useful manner. Usually,
   this data is derived from some external source. The ``add_participant()`` command,
@@ -155,4 +155,4 @@ object's type attribute:
   This command and various other commands are available as methods on the session's
   ``setup`` attribute. For more information, see :ref:`ref_syc_analysis_setup` and
   :ref:`ref_setup`.
-  
+

--- a/doc/source/users_guide/syc_persistence.rst
+++ b/doc/source/users_guide/syc_persistence.rst
@@ -100,15 +100,15 @@ The basic operations supported are:
     ...
 
     # Save the solution as a snapshot
-    case.save_snapshot(snapshot_name='Solution1')
+    case.save_snapshot(snapshot_name="Solution1")
 
     # Restore the the Initial snapshot from before solve
-    case.open_snapshot(snapshot_name='Initial')
+    case.open_snapshot(snapshot_name="Initial")
     # Make some changes and solve again
     ...
     solution.solve()
     # Save this solution to a snapshot
-    case.save_snapshot(snapshot_name='Solution2')
+    case.save_snapshot(snapshot_name="Solution2")
 
     # Query snapshots..
     case.get_snapshots()
@@ -120,7 +120,7 @@ The basic operations supported are:
     #
 
     # Delete Solution1
-    case.delete_snapshot(snapshot_name='Solution1')
+    case.delete_snapshot(snapshot_name="Solution1")
 
 Clearing the current state
 ---------------------------

--- a/doc/source/users_guide/syc_solution.rst
+++ b/doc/source/users_guide/syc_solution.rst
@@ -34,9 +34,10 @@ threads:
 .. code-block:: python
 
     import threading
+
     ...
 
-    solve_thread = threading.Thread(target = syc_session.solution.solve)
+    solve_thread = threading.Thread(target=syc_session.solution.solve)
 
     solve_thread.start()
 

--- a/examples/00-systemcoupling/oscillating_plate.py
+++ b/examples/00-systemcoupling/oscillating_plate.py
@@ -46,6 +46,7 @@ motion of the plate as it is damped.
 # sphinx_gallery_thumbnail_path = '_static/oscplate_displacement.png'
 import os
 from pprint import pprint
+
 import ansys.systemcoupling.core as pysystemcoupling
 from ansys.systemcoupling.core import examples
 
@@ -141,8 +142,11 @@ setup.coupling_participant.keys()
 # and both force and displacement data transfers.
 
 interface_name = setup.add_interface(
-    side_one_participant = mapdl_part_name, side_one_regions = ['FSIN_1'],
-    side_two_participant = fluent_part_name, side_two_regions = ['wall_deforming'])
+    side_one_participant=mapdl_part_name,
+    side_one_regions=["FSIN_1"],
+    side_two_participant=fluent_part_name,
+    side_two_regions=["wall_deforming"],
+)
 
 force_transfer_name = setup.add_data_transfer(
     interface=interface_name,

--- a/examples/00-systemcoupling/oscillating_plate.py
+++ b/examples/00-systemcoupling/oscillating_plate.py
@@ -32,7 +32,6 @@ motion of the plate as it is damped.
 
 """
 
-
 # %%
 # Set up example
 # --------------

--- a/examples/00-systemcoupling/parametric_sweep_vel.py
+++ b/examples/00-systemcoupling/parametric_sweep_vel.py
@@ -31,16 +31,14 @@ changing velocity value.
 # sphinx_gallery_thumbnail_path = '_static/param_sweep_flow.png'
 import os
 
+import ansys.dpf.core as pydpf
+import ansys.fluent.core as pyfluent
 import matplotlib.pyplot as plt
 import numpy as np
 
-import ansys.dpf.core as pydpf
-import ansys.fluent.core as pyfluent
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core.syc_version import SYC_VERSION_DOT
-
 from ansys.systemcoupling.core import examples
-
+from ansys.systemcoupling.core.syc_version import SYC_VERSION_DOT
 
 # %%
 # Define functions
@@ -62,6 +60,7 @@ from ansys.systemcoupling.core import examples
 # the Fluent files are placed in a ``Fluent`` subdirectory. The
 # ``setup_working_directory()`` function returns the path of the
 # working directory for later use.
+
 
 def setup_working_directory():
     examples.delete_downloads()
@@ -96,6 +95,7 @@ def setup_working_directory():
 
     return working_dir
 
+
 # %%
 # Set inlet velocity
 # ~~~~~~~~~~~~~~~~~~
@@ -105,18 +105,20 @@ def setup_working_directory():
 # with a varying ``inlet_velocity``value before each call of
 # the ``solve_coupled_analysis`` command in a sequence of analyses.
 
-def set_inlet_velocity(working_dir, inlet_velocity):
-  with pyfluent.launch_fluent(product_version=f"{SYC_VERSION_DOT}.0",
-                              precision="double",
-                              processor_count=2) as session:
-      case_file = os.path.join(working_dir, "Fluent", "case.cas.h5")
-      session.file.read(file_type="case", file_name=case_file)
-      session.setup.boundary_conditions.velocity_inlet[
-          "wall_inlet"
-      ].vmag.value = inlet_velocity
-      session.tui.file.write_case(case_file, "yes")
 
-  print(f"Inlet velocity is set to {inlet_velocity}")
+def set_inlet_velocity(working_dir, inlet_velocity):
+    with pyfluent.launch_fluent(
+        product_version=f"{SYC_VERSION_DOT}.0", precision="double", processor_count=2
+    ) as session:
+        case_file = os.path.join(working_dir, "Fluent", "case.cas.h5")
+        session.file.read(file_type="case", file_name=case_file)
+        session.setup.boundary_conditions.velocity_inlet[
+            "wall_inlet"
+        ].vmag.value = inlet_velocity
+        session.tui.file.write_case(case_file, "yes")
+
+    print(f"Inlet velocity is set to {inlet_velocity}")
+
 
 # %%
 # Solve coupled analysis
@@ -134,27 +136,39 @@ def set_inlet_velocity(working_dir, inlet_velocity):
 #    that the System Coupling session is properly exited at the
 #    end of the scope defined by the ``with`` block.
 
+
 def solve_coupled_analysis(working_dir):
     with pysyc.launch(working_dir=working_dir) as syc:
         print("Setting up the coupled analysis.")
 
         fluent_name = syc.setup.add_participant(
-            input_file = os.path.join("Fluent", "fluent.scp"))
+            input_file=os.path.join("Fluent", "fluent.scp")
+        )
 
         mapdl_name = syc.setup.add_participant(
-            input_file = os.path.join("Mapdl", "mapdl.scp"))
+            input_file=os.path.join("Mapdl", "mapdl.scp")
+        )
 
         fsi_name = syc.setup.add_interface(
-            side_one_participant = fluent_name, side_one_regions = ['wall_deforming'],
-            side_two_participant = mapdl_name, side_two_regions = ['FSIN_1'])
+            side_one_participant=fluent_name,
+            side_one_regions=["wall_deforming"],
+            side_two_participant=mapdl_name,
+            side_two_regions=["FSIN_1"],
+        )
 
         syc.setup.add_data_transfer(
-            interface = fsi_name, target_side = 'One',
-            source_variable = 'INCD', target_variable = 'displacement')
+            interface=fsi_name,
+            target_side="One",
+            source_variable="INCD",
+            target_variable="displacement",
+        )
 
         syc.setup.add_data_transfer(
-            interface = fsi_name, target_side = 'Two',
-            source_variable = 'force', target_variable = 'FORC')
+            interface=fsi_name,
+            target_side="Two",
+            source_variable="force",
+            target_variable="FORC",
+        )
 
         syc.setup.solution_control.maximum_iterations = 7
 
@@ -163,19 +177,21 @@ def solve_coupled_analysis(working_dir):
 
     print("...done.")
 
+
 # %%
 # Extract maximum displacement value
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Use PyDPF to query the MAPDL results for the extract the
 # maximum displacement value in the solution.
 def extract_max_displacement(working_dir):
-  print("Extracting max displacement value")
-  model = pydpf.Model(os.path.join(working_dir, "Mapdl", "file.rst"))
-  displacements = model.results.displacement()
-  fields = displacements.outputs.fields_container()
-  value = max([v[0] for v in fields[0].data])
-  print(f"Max displacement value = {value}")
-  return value
+    print("Extracting max displacement value")
+    model = pydpf.Model(os.path.join(working_dir, "Mapdl", "file.rst"))
+    displacements = model.results.displacement()
+    fields = displacements.outputs.fields_container()
+    value = max([v[0] for v in fields[0].data])
+    print(f"Max displacement value = {value}")
+    return value
+
 
 # %%
 # Get maximum displacement
@@ -186,10 +202,12 @@ def extract_max_displacement(working_dir):
 # - Run the coupled analysis based on this setting.
 # - Extract and return the maximum displacement value from the MAPDL results.
 
+
 def get_max_displacement(working_dir, inlet_velocity):
-  set_inlet_velocity(working_dir, inlet_velocity)
-  solve_coupled_analysis(working_dir)
-  return extract_max_displacement(working_dir)
+    set_inlet_velocity(working_dir, inlet_velocity)
+    solve_coupled_analysis(working_dir)
+    return extract_max_displacement(working_dir)
+
 
 # %%
 # Plot results
@@ -198,14 +216,16 @@ def get_max_displacement(working_dir, inlet_velocity):
 # displacement of the plate versus the inlet velocity.
 #
 def plot(working_dir, x, y):
-  fig, ax = plt.subplots()
-  ax.plot(x, y, "-o")
-  ax.set(
-    xlabel="Inlet velocity [m/s]",
-    ylabel='Max Displacement [m]',
-    title="Plate max displacement vs. inlet velocity")
-  ax.grid()
-  plt.savefig(os.path.join(working_dir, "displacement"))
+    fig, ax = plt.subplots()
+    ax.plot(x, y, "-o")
+    ax.set(
+        xlabel="Inlet velocity [m/s]",
+        ylabel="Max Displacement [m]",
+        title="Plate max displacement vs. inlet velocity",
+    )
+    ax.grid()
+    plt.savefig(os.path.join(working_dir, "displacement"))
+
 
 # %%
 # Run analyses
@@ -222,6 +242,6 @@ y = np.array([0.0] * len(x))
 working_dir = setup_working_directory()
 
 for index, inlet_velocity in enumerate(x):
-  y[index] = get_max_displacement(working_dir, inlet_velocity)
+    y[index] = get_max_displacement(working_dir, inlet_velocity)
 
 plot(working_dir, x, y)

--- a/examples/00-systemcoupling/parametric_sweep_vel.py
+++ b/examples/00-systemcoupling/parametric_sweep_vel.py
@@ -20,7 +20,6 @@ changing velocity value.
 
 """
 
-
 # %%
 # Perform required imports
 # ------------------------
@@ -112,9 +111,9 @@ def set_inlet_velocity(working_dir, inlet_velocity):
     ) as session:
         case_file = os.path.join(working_dir, "Fluent", "case.cas.h5")
         session.file.read(file_type="case", file_name=case_file)
-        session.setup.boundary_conditions.velocity_inlet[
-            "wall_inlet"
-        ].vmag.value = inlet_velocity
+        session.setup.boundary_conditions.velocity_inlet["wall_inlet"].vmag.value = (
+            inlet_velocity
+        )
         session.tui.file.write_case(case_file, "yes")
 
     print(f"Inlet velocity is set to {inlet_velocity}")

--- a/src/ansys/systemcoupling/core/util/pathstr.py
+++ b/src/ansys/systemcoupling/core/util/pathstr.py
@@ -22,6 +22,6 @@ def join_path_strs(*path_strs: Iterable[str]) -> str:
 
     .. note::
        A leading empty path component is required for a
-       leading path separtator (``/``) in the returned value.
+       leading path separator (``/``) in the returned value.
     """
     return "/".join(path_strs)


### PR DESCRIPTION
This is motivated by wanting to add the `add-license-header` hook from `ansys/pre-commit-hooks` to our pre-commit config. We can use `add-license-header` to update all of our code with the required license headers and maintain license headers in future. This hook will be added in a _follow-up_ PR. The aim here is create a good base for that addition.

* Bring some of the pre-commit tools up to date. 
* Relax the restrictions on directories the tools are applied to. 
* Run pre-commit over all files and merge updates.

Regarding the excluded directories, prior to this change we exclude `examples/` and `doc/`. It's not clear why these were excluded. Certainly, we don't want to exclude `examples/` when we add the license header hook. Also, we are at present effectively missing the use of the `blacken-docs` hook by excluding `doc/`. We _do_ want to exclude the `doc/source/examples` directory though, as this is derived from `examples/`.