### PR TITLE
Build 241 API using release image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: "3.8"
-  # Doc build dependencies now need Python >= 3.9.  For now, bump version for doc
-  # build only but consider bumping main version and delete this:
-  DOC_PYTHON_VERSION: "3.9"
+  MAIN_PYTHON_VERSION: "3.9"
   PACKAGE_NAME: "ansys-systemcoupling-core"
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
@@ -51,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: "Build wheelhouse and perform smoke test"
@@ -94,6 +91,13 @@ jobs:
           image-tag: v23.2.0
 
       - name: Generate API for v241
+        uses: ./.github/actions/generate-api
+        with:
+          image-tag: v24.1.0
+
+      # NB: try this in PR, but comment out before merging
+      #     uncomment after first SyC release targeting 24.1
+      - name: Generate API for v242
         uses: ./.github/actions/generate-api
         with:
           image-tag: latest
@@ -158,6 +162,13 @@ jobs:
       - name: Unit Test v24.1.0
         uses: ./.github/actions/unit-test
         with:
+          image-tag: v24.1.0
+          upload-coverage: false
+
+      # TODO comment out as for API generation
+      - name: Unit Test v24.2.0
+        uses: ./.github/actions/unit-test
+        with:
           image-tag: latest
           upload-coverage: false
 
@@ -172,7 +183,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.DOC_PYTHON_VERSION }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
       - name: Download package
         uses: actions/download-artifact@v4

--- a/src/ansys/systemcoupling/core/adaptor/impl/get_syc_version.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/get_syc_version.py
@@ -1,5 +1,7 @@
-from ansys.systemcoupling.core.syc_version import SYC_VERSION_DOT
 
+# This is the version we assume if no GetVersion query is available from
+# the SyC server.
+_FALLBACK_VERSION = "23.1"
 
 def get_syc_version(api) -> str:
     """Get the System Coupling version.
@@ -32,4 +34,4 @@ def get_syc_version(api) -> str:
 
     cmds = api.GetCommandAndQueryMetadata()
     exists = any(cmd["name"] == "GetVersion" for cmd in cmds)
-    return clean_version_string(api.GetVersion()) if exists else SYC_VERSION_DOT
+    return clean_version_string(api.GetVersion()) if exists else _FALLBACK_VERSION

--- a/src/ansys/systemcoupling/core/adaptor/impl/get_syc_version.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/get_syc_version.py
@@ -1,7 +1,7 @@
-
 # This is the version we assume if no GetVersion query is available from
 # the SyC server.
 _FALLBACK_VERSION = "23.1"
+
 
 def get_syc_version(api) -> str:
     """Get the System Coupling version.

--- a/tests/test_mocksolve_container.py
+++ b/tests/test_mocksolve_container.py
@@ -52,7 +52,7 @@ def test_partlib_cosim_volume_simple() -> None:
         messages = [
             msg for msg in setup.get_status_messages() if msg["level"] == "Information"
         ]
-        assert len(messages) == 0
+        assert len(messages) == 1
         assert messages[0]["path"] == "analysis_control"
         assert messages[0]["message"].startswith(
             "The data transfers define an optimized one-way workflow."

--- a/tests/test_mocksolve_container.py
+++ b/tests/test_mocksolve_container.py
@@ -24,14 +24,17 @@ def test_partlib_cosim_volume_simple() -> None:
             side_two_regions=["volume"],
         )
 
-        messages = setup.get_status_messages()
+        # As of 24.1 there are some expected warnings, so filter
+        # to Errors only
+        messages = [
+            msg for msg in setup.get_status_messages() if msg["level"] == "Error"
+        ]
 
         assert len(messages) == 1, print(messages)
         assert messages[0]["path"] == 'coupling_interface["Interface-1"]'
         assert messages[0]["message"].startswith(
             "No data transfers exist on Interface-1"
         )
-        assert messages[0]["level"] == "Error"
 
         dt1 = setup.add_data_transfer(
             interface=interface,

--- a/tests/test_mocksolve_container.py
+++ b/tests/test_mocksolve_container.py
@@ -43,14 +43,20 @@ def test_partlib_cosim_volume_simple() -> None:
             side_two_variable="p1_to_p2",
         )
 
-        messages = setup.get_status_messages()
+        messages = [
+            msg for msg in setup.get_status_messages() if msg["level"] == "Error"
+        ]
+        assert len(messages) == 0
 
-        assert len(messages) == 1
+        # At 24.1 there is a new Warning about unused input variables that we don't worry about here
+        messages = [
+            msg for msg in setup.get_status_messages() if msg["level"] == "Information"
+        ]
+        assert len(messages) == 0
         assert messages[0]["path"] == "analysis_control"
         assert messages[0]["message"].startswith(
             "The data transfers define an optimized one-way workflow."
         )
-        assert messages[0]["level"] == "Information"
 
         dt2 = setup.add_data_transfer(
             interface=interface,


### PR DESCRIPTION
The 24.1 API has up to now been built using the "latest" SyC image which was actually quite out of date. Switch now to the newly built `v24.1.0` image in preparation for next PySyC release. This is based on the 24.1 release build of SyC. 
 
Also adjust the list of Python versions we test against in line with other products. Drop 3.8 and add 3.11.

Also, fix an issue found during this work, whereby the `23_1` version of the API was not being built because of a logic error in the "get version" code. 