### PR TITLE
Prepare doc for next release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,12 +73,12 @@ in this order:
 
 * ``SYSC_ROOT``
 * ``AWP_ROOT``
-* ``AWP_ROOT232``
+* ``AWP_ROOT241``
 
 If a variable is set but does not refer to a valid installation, PySystemCoupling
 fails at that point, rather than attempting to use the next variable.
 
-In a standard user installation, the expectation is that only ``AWP_ROOT232`` is set.
+In a standard user installation, the expectation is that only ``AWP_ROOT241`` is set.
 
 (It is also possible to provide a different version number as an argument to the ``launch()``
 function. This will affect which ``AWP_ROOT<version>`` environment variable is examined.)
@@ -95,6 +95,7 @@ However, if you are transitioning existing scripts, the native System Coupling A
 as a convenience.
 
 .. note::
+
    While most commands should work as expected via the native System Coupling API,
    no guarantees can be given because of the nature of how it is exposed.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,33 +24,6 @@ author = "Ansys Inc."
 release = version = __version__
 cname = os.getenv("DOCUMENTATION_CNAME", "nocname.com")
 
-# use the default pyansys logo
-html_short_title = html_title = "PySystemCoupling"
-html_theme = "ansys_sphinx_theme"
-html_logo = pyansys_logo_black
-
-html_context = {
-    "github_user": "pyansys",
-    "github_repo": "pysystem-coupling",
-    "github_version": "main",
-    "doc_path": "doc/source",
-}
-
-# specify the location of your github repo
-html_theme_options = {
-    "github_url": "https://github.com/ansys/pysystem-coupling",
-    "show_prev_next": False,
-    "show_breadcrumbs": True,
-    "use_edit_page_button": True,
-    "additional_breadcrumbs": [
-        ("PyAnsys", "https://docs.pyansys.com"),
-    ],
-    "navigation_depth": -1,
-    "switcher": {
-        "json_url": f"https://{cname}/versions.json",
-        "version_match": get_version_match(__version__),
-    },
-}
 
 # Sphinx extensions
 extensions = [
@@ -216,14 +189,42 @@ sphinx_gallery_conf = {
 html_short_title = html_title = "PySystemCoupling"
 html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black
+DOCS_FQDN = "systemcoupling.docs.pyansys.com"
 html_theme_options = {
     "github_url": "https://github.com/ansys/pysystem-coupling",
     "show_prev_next": False,
     "show_breadcrumbs": True,
+    "use_edit_page_button": True,
     "additional_breadcrumbs": [
-        ("PyAnsys", "https://docs.pyansys.com/"),
+        ("PyAnsys", "https://docs.pyansys.com"),
     ],
     "navigation_depth": -1,
+    "collapse_navigation": True,
+    "icon_links": [
+        {
+            "name": "Support",
+            "url": "https://github.com/ansys/pysystem-coupling/discussions",
+            "icon": "fa fa-comment fa-fw",
+        },
+        {
+            "name": "Contribute",
+            "url": f"https://{DOCS_FQDN}/version/dev/getting_started/contribution.html",
+            "icon": "fa fa-wrench",
+        },
+    ],
+    "switcher": {
+        "json_url": f"https://{cname}/versions.json",
+        "version_match": get_version_match(__version__),
+    },
+}
+
+html_context = {
+    "display_github": True,  # Integrate GitHub
+    "github_user": "pyansys",
+    "github_repo": "pysystem-coupling",
+    "github_version": "main",
+    "doc_path": "doc/source",
+    "source_path": "src",
 }
 
 # additional logos for the latex coverpage

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -189,7 +189,6 @@ sphinx_gallery_conf = {
 html_short_title = html_title = "PySystemCoupling"
 html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black
-DOCS_FQDN = "systemcoupling.docs.pyansys.com"
 html_theme_options = {
     "github_url": "https://github.com/ansys/pysystem-coupling",
     "show_prev_next": False,
@@ -203,12 +202,12 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "Support",
-            "url": "https://github.com/ansys/pysystem-coupling/discussions",
+            "url": "https://github.com/ansys/pysystem-coupling/issues",
             "icon": "fa fa-comment fa-fw",
         },
         {
             "name": "Contribute",
-            "url": f"https://{DOCS_FQDN}/version/dev/getting_started/contribution.html",
+            "url": "https://systemcoupling.docs.pyansys.com/version/dev/contributing.html",
             "icon": "fa fa-wrench",
         },
     ],

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -41,31 +41,31 @@ after the preceding steps for cloning and installing the package.
 
 The generated code is written to the directory ``src/ansys/systemcoupling/core/adaptor/api_<version>``,
 where ``<version>`` is the version of the System Coupling instance that was run in the background
-by the generation script. For example, the version ``23_2`` corresponds to the System Coupling 2023 R2.
-The default is ``23_2``, which means that this release of System Coupling is expected to be at the
-installation location given by the ``AWP_ROOT232`` environment variable.
+by the generation script. For example, the version ``24_1`` corresponds to the System Coupling 2024 R1.
+The default is ``24_1``, which means that this release of System Coupling is expected to be at the
+installation location given by the ``AWP_ROOT241`` environment variable.
 
 You can override the default behavior and run a different version, and generate the API classes for
 this different version, by setting either the ``SYSC_ROOT`` environment variable to point to the
 root directory of your System Coupling installation or the ``AWP_ROOT`` environment variable to
 point to the root of an Ansys installation. If ``SYSC_ROOT`` and ``AWP_ROOT`` environment variables
 are both set, the former takes priority. Additionally, both of these environment variables take priority
-over the ``AWP_ROOT232`` environment variable.
+over the ``AWP_ROOT241`` environment variable.
 
 
 Build documentation
 -------------------
-To build the PySystemCoupling documentation locally, you must have first generated the API classes
-as described in :ref:`ref_generate_api`. This is because some of the documentation is extracted
-from these classes.
+Before building the PySystemCoupling documentation locally, ensure that you have followed the
+steps to generate the API classes as described in :ref:`ref_generate_api`. This is necessary
+because some of the documentation is extracted from these API classes.
 
 Because multiple versions of the API classes can exist, you must set the ``PYSYC_DOC_BUILD_VERSION``
 environment variable to tell the documentation build which version to use. Given that there is
 no default for this environment variable, you *must* set it. The value should be a string in the
 same form as the ``<version>`` component of the ``api_<version>`` directory. For example,
-"23_2".
+"24_1".
 
-With this variable set, run this code to build the documentation:
+With this variable set, run these commands to build the documentation:
 
 .. code::
 
@@ -87,9 +87,10 @@ Run Sphinx Gallery examples
 ---------------------------
 The *Sphinx Gallery* examples are *not* run as part of a documentation build by default.
 This is because realistic runs of System Coupling, involving both System Coupling itself
-*and* the participant solvers, are not currently possible on GitHub. Therefore, examples
-are run manually from time to time and the resulting `Sphinx` files are committed to the
-repository.
+*and* the participant solvers, are not currently possible on the build runners that are
+available for PySystemCoupling's GitHub repository. Therefore, examples have to be run
+manually from time to time in a local development environment, and the resulting `Sphinx`
+files committed to the repository.
 
 To override the default behavior and rebuild the entire documentation, including
 regeneration of the Sphinx Gallery examples, set the ``PYSYC_BUILD_SPHINX_GALLERY``

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -12,7 +12,7 @@ PySystemCoupling supports Ansys System Coupling version 2023 R1 and later.
 
    The detailed documentation, particularly that in the :ref:`ref_index_api`
    section, is based on the *current* official Ansys release at this release of
-   PySystemCoupling. This is **2023 R2**. Although the majority of it does not change
+   PySystemCoupling. This is **2024 R1**. Although the majority of it does not change
    between releases, you should consult the API documentation for an earlier
    applicable release of PySystemCoupling if you are running with an older System
    Coupling version and want to be sure of the details.
@@ -24,8 +24,8 @@ the `Ansys <https://www.ansys.com/>`_ website.
 Install PySystemCoupling
 ========================
 
-The ``ansys-systemcoupling-core`` package currently supports Python 3.7 through
-Python 3.10 on Windows and Linux.
+The ``ansys-systemcoupling-core`` package currently supports Python 3.8 through
+Python 3.11 on Windows and Linux.
 
 Install the latest release from `PyPI <https://pypi.org/project/ansys-systemcoupling-core/>`_
 with this command:

--- a/doc/source/users_guide/analysis_setup.rst
+++ b/doc/source/users_guide/analysis_setup.rst
@@ -156,7 +156,7 @@ In the preceding setup, the important unset values are those for ``solution_cont
 These unset values are addressed later because they are considered to be errors in the setup.
 Unless values are provided, the solution is blocked.
 
-While some settings in the ``coupling_participant`` objects have ``<None>`` values, these
+While some settings in the above ``coupling_participant`` objects have ``<None>`` values, these
 unset values are not considered to be missing values nor indicate any kind of error in the
 setup. They are rather more specialized optional settings that have not been provided in
 the relevant input files.
@@ -304,8 +304,8 @@ can use the ``level`` field in a message dictionary to filter the message list:
     object, but the specific settings causing the error are indicated in the message itself.
     However, the setting names referenced in the message (such as ``'TimeStepSize'`` and
     ``'EndTime'``) are in the form that is used in System Coupling's native API. This reflects the
-    way that ``get_status_messages`` is exposed into PySystemCoupling, which
-    does not allow for reliable automatic translation to PySystemCoupling naming. You should
+    way that ``get_status_messages`` is exposed into PySystemCoupling, which does not currently
+    allow for reliable automatic translation to PySystemCoupling naming. You should
     be able to infer the PySystemCoupling names relatively easily by assuming a conversion
     from *camel case* to *snake case*.
 

--- a/doc/source/users_guide/index.rst
+++ b/doc/source/users_guide/index.rst
@@ -50,7 +50,7 @@ A ``Session`` object is the client-side access point in PySystemCoupling to a Sy
 This object exposes an API that allows a System Coupling analysis to be set up and solved. One or more
 such server sessions can be launched simultaneously from the client.
 
-In addition to providing an API for setting up and solving coupled analyses, the``Session``
+In addition to providing an API for setting up and solving coupled analyses, the ``Session``
 object provides access to a few basic capabilities described in the sections that follow.
 
 Connection check
@@ -87,8 +87,8 @@ You can turn off output streaming using this code to call the ``end_output()`` m
 Exiting
 -------
 When you are finished with a PySystemCoupling session, it is advisable to end it cleanly using the
-``exit()`` method. Otherwise, PySystemCoupling still attempts to clean up active server sessions
-when the Python environment is exited, which is naturally less reliable than a directed exit.
+``exit()`` method. If you do not do this, PySystemCoupling will still attempt to clean up any active server sessions
+when the Python environment is exited, but this is naturally less reliable than a directed exit.
 
 Once you use the following code to call the ``exit()`` method on a session object, the object
 is no longer usable.

--- a/doc/source/users_guide/syc_solution.rst
+++ b/doc/source/users_guide/syc_solution.rst
@@ -13,7 +13,7 @@ operations associated with solving an analysis and examining results data.
 The ``solve`` command
 ----------------------
 
-If you have set up an analysis and it has no errors, you may attempt to solve it by calling ``solve``. 
+If you have set up an analysis and it has no errors, you may attempt to solve it by calling ``solve``.
 
 .. tip::
     Before beginning the solve, you may wish to enable output streaming so you can use the solver transcript output to track the solution's progress.
@@ -41,7 +41,7 @@ threads:
 
     solve_thread.start()
 
-    # Do other thing in the Python environment
+    # Do other things in the Python environment
     ...
 
     # wait for solve to finish
@@ -56,14 +56,16 @@ Interrupting and aborting a solve
 You can interrupt or force the end of a solve using the ``solution.interrupt()`` and ``solution.abort()`` calls. These are unusual PySystemCoupling calls in that they *must* be called in a different thread from the one in which ``solve`` is executing.
 
 Both calls have the effect of stopping the solve that is in progress. The key difference
-is that ``interrupt`` supports the resumption of the solve (by calling ``solve`` again).
+is that ``interrupt`` allows you to resume the solve (by calling ``solve`` again).
 
 Low-level solution control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Commands are available for more advanced scenarios offering lower-level control over the
 solution process --- specifically ``initialize``, ``step``, ``create_restart_point``
-and ``shutdown``. Roughly speaking, these perform the individual actions that are usually encapsulated in a simple ``solve`` call, allowing Custom code to be executed between these actions.
+and ``shutdown``. Roughly speaking, these perform the individual actions that are usually
+encapsulated in a simple ``solve`` call, allowing custom code to be executed between these
+actions.
 
 Such advanced usage is not within the scope of this guide.
 

--- a/src/ansys/systemcoupling/core/__init__.py
+++ b/src/ansys/systemcoupling/core/__init__.py
@@ -69,7 +69,7 @@ def launch(
         (The forms ``"23.1"`` and ``"23_1"`` are also acceptable.)
         The version will be sought in the standard installation location. The
         default is ``None``, which is equivalent to specifying
-        ``"232"`` ("2023 R2" release), unless either of the environment
+        ``"241"`` ("2024 R1" release), unless either of the environment
         variables ``SYSC_ROOT`` or ``AWP_ROOT`` has been set. It is considered
         to be an error if either these is set *and* ``version`` is provided.
     extra_args : List[str]


### PR DESCRIPTION
* Modify any references to current/default version to refer to 24.1.
* General sweep through doc to pick up any issues, tweak wording here and there, etc.
* Fix navigation bar - version selector had been removed at some point.