### PR TITLE
Bump version to 0.5.dev0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           image-tag: v24.1.0
 
+      - name: Generate API for v242
+        uses: ./.github/actions/generate-api
+        with:
+          image-tag: latest
+
       - name: Clean out dist
         run: rm -rf dist
 
@@ -157,6 +162,13 @@ jobs:
         with:
           image-tag: v24.1.0
           upload-coverage: true
+
+      - name: Unit Test v24.2.0
+        uses: ./.github/actions/unit-test
+        with:
+          image-tag: latest
+          upload-coverage: false
+
 
   docs:
     name: Build Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-systemcoupling-core"
-version = "0.4.dev0"
+version = "0.5.dev0"
 description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
 requires-python = ">=3.7"


### PR DESCRIPTION
New version bump following 0.4.0 release.

Start building 24.2 API and run unit tests for 24.2 using "latest" image.