### PR TITLE
Support 'PIM' launch in configured environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ maintainers = [
 ]
 dependencies = [
 	"ansys-api-systemcoupling==0.1.0",
+    "ansys-platform-instancemanagement~=1.0",
 	"grpcio>=1.30.0",
 	"grpcio-status>=1.30.0,<1.62.1",
 	"googleapis-common-protos>=1.50.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 ]
 dependencies = [
 	"ansys-api-systemcoupling==0.1.0",
-    "ansys-platform-instancemanagement~=1.0",
+        "ansys-platform-instancemanagement~=1.0",
 	"grpcio>=1.30.0",
 	"grpcio-status>=1.30.0,<1.62.1",
 	"googleapis-common-protos>=1.50.0",

--- a/src/ansys/systemcoupling/core/client/grpc_client.py
+++ b/src/ansys/systemcoupling/core/client/grpc_client.py
@@ -270,10 +270,10 @@ class SycGrpc(object):
             # Remove from atexit cleanup list
             del SycGrpc._instances[self.__id]
 
-        if self.__skip_exit:
-            return
+        # if self.__skip_exit:
+        #    return
 
-        if self.__channel is not None:
+        if self.__channel is not None and not self.__skip_exit:
             try:
                 self.__ostream_service.end_streaming()
             except Exception as e:

--- a/src/ansys/systemcoupling/core/client/grpc_client.py
+++ b/src/ansys/systemcoupling/core/client/grpc_client.py
@@ -40,6 +40,7 @@ from ansys.systemcoupling.core.client.syc_container import start_container
 from ansys.systemcoupling.core.client.syc_process import SycProcess
 from ansys.systemcoupling.core.client.variant import from_variant, to_variant
 from ansys.systemcoupling.core.syc_version import normalize_version
+from ansys.systemcoupling.core.util.file_transfer import file_transfer_service
 from ansys.systemcoupling.core.util.logging import LOG
 
 _CHANNEL_READY_TIMEOUT_SEC = 15
@@ -153,6 +154,10 @@ class SycGrpc(object):
         self._connect(_LOCALHOST_IP, port)
 
     def start_pim_and_connect(self, version: str = None):
+        """Start PIM-managed instance.
+
+        Currently for internal use only.
+        """
         product_version = "latest"
         if version is not None:
             maj_v, min_v = normalize_version(version)
@@ -166,6 +171,20 @@ class SycGrpc(object):
         self.__pim_instance = instance
         channel = instance.build_grpc_channel()
         self._connect(channel=channel)
+
+    def upload_file(self, *args, **kwargs):
+        """Supports file upload to remote instance.
+
+        Currently for internal use only.
+        """
+        file_transfer_service(self.__pim_instance).upload_file(*args, **kwargs)
+
+    def download_file(self, *args, **kwargs):
+        """Supports file download from remote instance.
+
+        Currently for internal use only.
+        """
+        file_transfer_service(self.__pim_instance).download_file(*args, **kwargs)
 
     def connect(self, host, port):
         """Connect to an already running System Coupling server running on a known
@@ -269,9 +288,6 @@ class SycGrpc(object):
         if self.__id in SycGrpc._instances:
             # Remove from atexit cleanup list
             del SycGrpc._instances[self.__id]
-
-        # if self.__skip_exit:
-        #    return
 
         if self.__channel is not None and not self.__skip_exit:
             try:

--- a/src/ansys/systemcoupling/core/session.py
+++ b/src/ansys/systemcoupling/core/session.py
@@ -209,6 +209,51 @@ class Session:
         """The gRPC connection object, exposed for testing purposes only."""
         return self.__rpc
 
+    def upload_file(
+        self,
+        file_name: str,
+        remote_file_name: Optional[str] = None,
+        overwrite: bool = False,
+    ):
+        """For internal use only: upload a file to the PIM-managed instance.
+
+        Reduces to a no-op if the System Coupling instance is not managed by PIM.
+
+        The remote file may optionally be given a different name from the local one.
+
+        Unless ``overwrite`` is ``True``, a ``FileExistsError`` will be raised if
+        the remote file already exists.
+
+        Parameters
+        ----------
+        file_name : str
+            local file name
+        remote_file_name : str, optional
+            remote file name - default is None
+        overwrite: bool, optional
+            whether to overwrite the remote file if it already exists - default is False
+        """
+        self.__rpc.upload_file(file_name, remote_file_name, overwrite)
+
+    def download_file(
+        self, file_name: str, local_file_dir: str = ".", overwrite: bool = False
+    ):
+        """For internal use only: download a file from the PIM-managed instance.
+
+        Unless ``overwrite`` is ``True``, a ``FileExistsError`` will be raised if
+        the local file already exists.
+
+        Parameters
+        ----------
+        file_name : str
+            file name
+        local_file_dir : str, optional
+            local directory to write the file - default is current directory, "."
+        overwrite : bool, optional
+            whether to overwrite the remote file if it already exists - default is False
+        """
+        self.__rpc.download_file(file_name, local_file_dir, overwrite)
+
     def __enter__(self):
         return self
 

--- a/src/ansys/systemcoupling/core/session.py
+++ b/src/ansys/systemcoupling/core/session.py
@@ -204,6 +204,11 @@ class Session:
             self.__native_api = NativeApi(self.__rpc)
         return self.__native_api
 
+    @property
+    def _grpc(self):
+        """The gRPC connection object, exposed for testing purposes only."""
+        return self.__rpc
+
     def __enter__(self):
         return self
 

--- a/src/ansys/systemcoupling/core/util/file_transfer.py
+++ b/src/ansys/systemcoupling/core/util/file_transfer.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+from typing import Any, Optional, Protocol
+
+
+class FileTransferService(Protocol):
+    def upload_file(
+        self, file_name: str, remote_file_name: Optional[str], overwrite: bool
+    ): ...
+
+    def download_file(self, file_name: str, local_file_dir: str, overwrite: bool): ...
+
+
+class NullFileTransferService(FileTransferService):
+    """A do-nothing implementation of file upload/download service."""
+
+    ...
+
+
+class PimFileTransferService:
+    """Provides a file upload and download service for the case when PySystemCoupling
+    is running as a remote instance managed by
+    `PyPIM<https://pypim.docs.pyansys.com/version/stable/>`.
+
+    Currently for internal use only.
+
+    """
+
+    def __init__(self, pim_instance: Any):
+
+        self.pim_instance = pim_instance
+        self.file_service = None
+
+        try:
+            upload_server = self.pim_instance.services["http-simple-upload-server"]
+        except KeyError:
+            raise RuntimeError("PIM instance is not configured with the upload service")
+        else:
+            # This import is available in the Ansys Lab environment
+            from simple_upload_server.client import Client
+
+            self.file_service = Client(
+                token="token",
+                url=upload_server.uri,
+                headers=upload_server.headers,
+            )
+
+    def upload_file(
+        self, file_name: str, remote_file_name: Optional[str], overwrite: bool
+    ):
+        """Upload a file to the PIM-managed instance.
+
+        The remote file may optionally be given a different name from the local one.
+
+        Unless ``overwrite`` is ``True``, a ``FileExistsError`` will be raised if
+        the remote file already exists.
+
+        Parameters
+        ----------
+        file_name : str
+            local file name
+        remote_file_name : str or None
+            remote file name (or use local file name if None)
+        overwrite: bool
+            whether to overwrite the remote file if it already exists
+        """
+        if os.path.isfile(file_name):
+            remote_file_name = remote_file_name or os.path.basename(file_name)
+            if not overwrite and self.file_service.file_exist(remote_file_name):
+                raise FileExistsError(f"{remote_file_name} already exists remotely.")
+            self.file_service.upload_file(file_name, remote_file_name)
+        else:
+            raise FileNotFoundError(f"Local file {file_name} does not exist.")
+
+    def download_file(self, file_name: str, local_file_dir: str, overwrite: bool):
+        """Download a file from the PIM-managed instance.
+
+        Unless ``overwrite`` is ``True``, a ``FileExistsError`` will be raised if
+        the local file already exists.
+
+        Parameters
+        ----------
+        file_name : str
+            file name
+        local_file_dir : str
+            local directory to write the file
+        overwrite : bool
+            whether to overwrite the remote file if it already exists
+        """
+        if self.file_service.file_exist(file_name):
+            if not overwrite:
+                local_file_path = os.path.join(local_file_dir, file_name)
+                if os.path.isfile(local_file_path):
+                    raise FileExistsError(
+                        f"Local file {local_file_path} already exists."
+                    )
+            self.file_service.download_file(file_name, local_file_dir)
+        else:
+            raise FileNotFoundError(f"Remote file {file_name} does not exist.")
+
+
+def file_transfer_service(pim_instance: Optional[Any] = None) -> FileTransferService:
+    """If a ``PIM`` instance is provided, returns an object providing remote
+    file upload and download, otherwise returns a 'no-op' version of the object.
+    """
+    if pim_instance:
+        return PimFileTransferService(pim_instance)
+    else:
+        return NullFileTransferService()

--- a/src/ansys/systemcoupling/core/util/file_transfer.py
+++ b/src/ansys/systemcoupling/core/util/file_transfer.py
@@ -24,7 +24,8 @@ import os
 from typing import Any, Optional, Protocol
 
 
-class FileTransferService(Protocol):
+# Note: generally exclude items in this file from coverage for now
+class FileTransferService(Protocol):  # pragma: no cover
     def upload_file(
         self, file_name: str, remote_file_name: Optional[str], overwrite: bool
     ): ...
@@ -32,13 +33,13 @@ class FileTransferService(Protocol):
     def download_file(self, file_name: str, local_file_dir: str, overwrite: bool): ...
 
 
-class NullFileTransferService(FileTransferService):
+class NullFileTransferService(FileTransferService):  # pragma: no cover
     """A do-nothing implementation of file upload/download service."""
 
     ...
 
 
-class PimFileTransferService:
+class PimFileTransferService:  # pragma: no cover
     """Provides a file upload and download service for the case when PySystemCoupling
     is running as a remote instance managed by
     `PyPIM<https://pypim.docs.pyansys.com/version/stable/>`.
@@ -120,7 +121,9 @@ class PimFileTransferService:
             raise FileNotFoundError(f"Remote file {file_name} does not exist.")
 
 
-def file_transfer_service(pim_instance: Optional[Any] = None) -> FileTransferService:
+def file_transfer_service(
+    pim_instance: Optional[Any] = None,
+) -> FileTransferService:  # pragma: no cover
     """If a ``PIM`` instance is provided, returns an object providing remote
     file upload and download, otherwise returns a 'no-op' version of the object.
     """

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -98,3 +98,6 @@ def test_pim(monkeypatch, with_launching_container):
 
     # It connected using the channel created by PyPIM
     assert syc._grpc._channel == pim_channel
+
+    syc.exit()
+    assert mock_instance.delete.called

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import create_autospec
+
+import ansys.platform.instancemanagement as pypim
+import grpc
+
+import ansys.systemcoupling.core as pysystemcoupling
+
+
+def test_pim(monkeypatch):
+    # Start the product
+    syc = pysystemcoupling.launch()
+
+    # Create a mock PyPIM instance object representing the running product
+    mock_instance = pypim.Instance(
+        definition_name="definitions/fake-syc",
+        name="instances/fake-syc",
+        ready=True,
+        status_message=None,
+        services={"grpc": pypim.Service(uri=syc._grpc._channel_str, headers={})},
+    )
+
+    # Create a working gRPC channel to this product
+    pim_channel = grpc.insecure_channel(syc._grpc._channel_str)
+
+    # Mock the wait_for_ready method so that it immediately returns
+    mock_instance.wait_for_ready = create_autospec(mock_instance.wait_for_ready)
+
+    # Mock the `build_grpc_channel` to return the working channel
+    mock_instance.build_grpc_channel = create_autospec(
+        mock_instance.build_grpc_channel, return_value=pim_channel
+    )
+
+    # Mock the deletion method
+    mock_instance.delete = create_autospec(mock_instance.delete)
+
+    # Mock the PyPIM client so that on the "create_instance" call it returns the mock instance
+    # Note: the host and port here will not be used.
+    mock_client = pypim.Client(channel=grpc.insecure_channel("localhost:12345"))
+    mock_client.create_instance = create_autospec(
+        mock_client.create_instance, return_value=mock_instance
+    )
+
+    # Mock the general PyPIM connection and configuration check method to expose the mock client.
+    mock_connect = create_autospec(pypim.connect, return_value=mock_client)
+    mock_is_configured = create_autospec(pypim.is_configured, return_value=True)
+    monkeypatch.setattr(pypim, "connect", mock_connect)
+    monkeypatch.setattr(pypim, "is_configured", mock_is_configured)
+
+    # This initial setup is faking all the necessary parts of PyPIM. From here,
+    # calling the launch() method with no parameter is expected to
+    # call only the mocks, which the test should now do:
+
+    syc = pysystemcoupling.launch()
+    # After this call, the test is ready to make all the assertions verifying
+    # that the PyPIM workflow was applied:
+
+    # Unlike Fluent and MAPDL, we only support "skip exit" as a backdoor for testing
+    syc._grpc._skip_exit = True
+
+    # The launch method checked if it was in a PyPIM environment
+    assert mock_is_configured.called
+
+    # It connected to PyPIM
+    assert mock_connect.called
+
+    # It created a remote instance through PyPIM
+    mock_client.create_instance.assert_called_with(
+        product_name="systemcoupling", product_version="latest"
+    )
+
+    # It waited for this instance to be ready
+    assert mock_instance.wait_for_ready.called
+
+    # It created an gRPC channel from this instance
+    assert mock_instance.build_grpc_channel.called
+
+    # It connected using the channel created by PyPIM
+    assert syc._grpc._channel == pim_channel

--- a/tests/test_pim.py
+++ b/tests/test_pim.py
@@ -28,8 +28,8 @@ import grpc
 import ansys.systemcoupling.core as pysystemcoupling
 
 
-def test_pim(monkeypatch):
-    # Start the product
+def test_pim(monkeypatch, with_launching_container):
+    # Launch the product "normally" - this will stand in for the container launched by PIM
     syc = pysystemcoupling.launch()
 
     # Create a mock PyPIM instance object representing the running product


### PR DESCRIPTION
Modify `launch()` such that if we are running in an environment where `PyPIM` is configured, PIM will be used to launch an instance and it will be connected to.

Also expose a direct `launch_remote()` function that assumes that `PyPIM` is known to be configured.

In addition `upload_file` and `download_file` methods are added to the `Session` interface. These reduce to doing nothing unless `pyPIM` is configured. In a PIM environment they are needed to be able to exchange files with the remote instance as there is no mapping of the container file system to the local one.