### PR TITLE
Fix supported Python version range

### DIFF
--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -24,8 +24,8 @@ the `Ansys <https://www.ansys.com/>`_ website.
 Install PySystemCoupling
 ========================
 
-The ``ansys-systemcoupling-core`` package currently supports Python 3.8 through
-Python 3.11 on Windows and Linux.
+The ``ansys-systemcoupling-core`` package currently supports Python 3.9 through
+Python 3.12 on Windows and Linux.
 
 Install the latest release from `PyPI <https://pypi.org/project/ansys-systemcoupling-core/>`_
 with this command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-systemcoupling-core"
 version = "0.5.dev0"
 description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.9,<3.13"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
@@ -35,10 +35,10 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bring PySystemCoupling into line with other products, where the current  range of supported Python versions is `>=3.9, <3.13`.

This should have been updated for the recent release. The changes here will be cherry-picked into a new point release.