### PR TITLE
fix: use a named logger instead of the global logger

### DIFF
--- a/src/ansys/systemcoupling/core/util/logging.py
+++ b/src/ansys/systemcoupling/core/util/logging.py
@@ -55,7 +55,7 @@ class Logger:
     """
 
     def __init__(self, level: Any = logging.ERROR):
-        self.logger = logging.getLogger(__name__)
+        self.logger = logging.getLogger("pysystem-coupling")
         self.stream_handler = None
         self.file_handler = None
         self.log_filepath = None

--- a/src/ansys/systemcoupling/core/util/logging.py
+++ b/src/ansys/systemcoupling/core/util/logging.py
@@ -55,7 +55,7 @@ class Logger:
     """
 
     def __init__(self, level: Any = logging.ERROR):
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(__name__)
         self.stream_handler = None
         self.file_handler = None
         self.log_filepath = None


### PR DESCRIPTION
Context: We use pysystem-coupling for the Volitare solution. Volitare is a SAF-based solution. GLOW provides logging infrastructure for us to use the native Python logging module to write to SAF log files. We found an issue where specific logging levels (debug, info) were not writing to the SAF log files.

After a deep investigation, I found the culprit to be this block of code. Specifically, [line 66](https://github.com/ansys/pysystem-coupling/blob/b71a597027b02302084ea9c6a026c850486a6320/src/ansys/systemcoupling/core/util/logging.py#L66), combined with the fact that the default value for `level` on line 57 is `ERROR`, means that the log level for the global Python logger is set in any Python script where SyC is imported. You can see what that looks like for Volitare [here](https://github.com/ansys-internal/volitare/blob/e888211809c34c0057312fd7e12e1724a063f2b0/src/ansys/solutions/volitare/scripts/mapping_stage.py#L12)

Caveat: I do not know how to test SyC - and I don't know if this change has other implications as I do not understand your architecture. If this change is not appropriate, please propose an alternative, as the current implementation isn't correct.

EDIT: For any others who encounter this issue, here is our [temporary workaround](https://github.com/ansys-internal/volitare/pull/158/commits/952c5bff736bd77f4fb30d42837dece11249c3e4) in Volitare to manually fix the global logging level. This code block needs to be added to any file that imports pysystem-coupling.