### PR TITLE
Add unit test for recent participant manager changes

### DIFF
--- a/tests/test_participant_mgr.py
+++ b/tests/test_participant_mgr.py
@@ -229,6 +229,8 @@ def test_add_participant_regionstate(
 
     syc = MockSycSession()
     part = Participant()
+
+    # Monkey patch `get_regions` as the default just returns an empty list.
     part.get_regions = lambda: [
         (
             Region("region1", "Region1", "Surface", ["a"], ["b"], "Point Cloud Region")


### PR DESCRIPTION
There was an existing unit test  for `participant_manager` but it used a `NullState` mock object to represent the setup state, which meant that certain outcomes in the code being tested could not be probed. In particular, we wanted to test recent changes related to a `region_discretization_type` setting. The setup `NullState` has been replaced with a new dict-like mock object that allows us to query the state that has been set and compare against expected outcomes in different scenarios.

The new mock object is also a potentially useful tool for testing future changes.