### PR TITLE
Pass whole Session object into get_injected_cmd_map

### DIFF
--- a/src/ansys/systemcoupling/core/adaptor/impl/injected_commands.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/injected_commands.py
@@ -111,7 +111,7 @@ def _wrap_add_participant(
     session: SessionProtocol, part_mgr: ParticipantManager, **kwargs
 ) -> str:
     setup = session.setup
-    if session := kwargs.get("participant_session", None):
+    if participant_session := kwargs.get("participant_session", None):
         if len(kwargs) != 1:
             raise RuntimeError(
                 "If a 'participant_session' argument is passed to "
@@ -121,18 +121,20 @@ def _wrap_add_participant(
             raise RuntimeError("Internal error: participant manager is not available.")
 
         # special handling for mapdl session
-        if "ansys.mapdl.core.mapdl_grpc.MapdlGrpc" in str(type(session)):
+        if "ansys.mapdl.core.mapdl_grpc.MapdlGrpc" in str(type(participant_session)):
             return part_mgr.add_participant(
-                participant_session=MapdlSystemCouplingInterface(session)
+                participant_session=MapdlSystemCouplingInterface(participant_session)
             )
 
-        if not hasattr(session, "system_coupling"):
+        if not hasattr(participant_session, "system_coupling"):
             raise RuntimeError(
                 "The 'participant_session' parameter does not provide a "
                 "'system_coupling' attribute and therefore cannot support this "
                 "form of 'add_participant'."
             )
-        return part_mgr.add_participant(participant_session=session.system_coupling)
+        return part_mgr.add_participant(
+            participant_session=participant_session.system_coupling
+        )
 
     if input_file := kwargs.get("input_file", None):
         session.upload_file(input_file)

--- a/src/ansys/systemcoupling/core/adaptor/impl/injected_commands.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/injected_commands.py
@@ -56,8 +56,8 @@ def get_injected_cmd_map(
 
     Whereas the set of commands that exists by default on the API represents a relatively
     mechanical exposure of native System Coupling commands to PySystemCoupling, the
-    "injected commands" that are returned from here are either _additional_ commands
-    that have no counterpart in System Coupling, or are _overrides_ to existing commands
+    "injected commands" that are returned from here are either *additional* commands
+    that have no counterpart in System Coupling, or are *overrides* to existing commands
     that provide modified or extended behavior.
 
     """

--- a/src/ansys/systemcoupling/core/participant/manager.py
+++ b/src/ansys/systemcoupling/core/participant/manager.py
@@ -156,9 +156,6 @@ class ParticipantManager:
         if self.__solve_exception:
             raise self.__solve_exception
 
-    def upload_file(self, file_name: str):
-        self.__syc_session.upload_file(file_name)
-
     def _do_solve(self, syc_solve_thread):
         connection_threads = [
             threading.Thread(

--- a/src/ansys/systemcoupling/core/session.py
+++ b/src/ansys/systemcoupling/core/session.py
@@ -179,7 +179,7 @@ class Session:
         if self.__part_mgr is None:
             self.__part_mgr = ParticipantManager(self, self.__syc_version)
         sycproxy.set_injected_commands(
-            get_injected_cmd_map(category, root, self.__part_mgr, self.__rpc)
+            get_injected_cmd_map(category, self, self.__part_mgr, self.__rpc)
         )
         return (root, sycproxy)
 


### PR DESCRIPTION
It has been found in some current WIP that passing the "category root" API object into `get_injected_cmd_map` is not always sufficient and that having access to the `Session` can make sense. As this is a change that potentially is more widely useful, it is being factored out now from the WIP branch. This will also simplify the WIP branch and help to avoid the possibility of conflicts.
