### PR TITLE
Switch from "latest" to recent "v24.2.0" container for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Generate API for v242
         uses: ./.github/actions/generate-api
         with:
-          image-tag: latest
+          image-tag: v24.2.0
 
       - name: Clean out dist
         run: rm -rf dist
@@ -167,7 +167,7 @@ jobs:
       - name: Unit Test v24.2.0
         uses: ./.github/actions/unit-test
         with:
-          image-tag: latest
+          image-tag: v24.2.0
           upload-coverage: false
 
 


### PR DESCRIPTION
Current code base targets 24.1 by default and has been using the "latest" container, generated during 24.2 development, for unit testing and API generation of 24.2. Switching now to use a recently built v24.2.0 container, This frees us up to start using "latest" for 25.1 and is also the first step on the way to preparing for a new release of PySystemCoupling, targeting 24.2.