### PR TITLE
Query of missing property now returns None

### DIFF
--- a/src/ansys/systemcoupling/core/adaptor/impl/syc_proxy.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/syc_proxy.py
@@ -89,6 +89,9 @@ class SycProxy(SycProxyInterface):
             return adapt_native_named_object_keys(state)
         return state
 
+    def get_property_state(self, path, property):
+        return self.__rpc.GetParameter(ObjectPath=path, Name=property)
+
     def delete(self, path):
         self.__rpc.DeleteObject(ObjectPath=path)
 

--- a/src/ansys/systemcoupling/core/adaptor/impl/syc_proxy_interface.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/syc_proxy_interface.py
@@ -49,6 +49,10 @@ class SycProxyInterface(ABC):  # pragma: no cover
         pass
 
     @abstractmethod
+    def get_property_state(self, path, name):
+        pass
+
+    @abstractmethod
     def delete(self, path):
         pass
 

--- a/src/ansys/systemcoupling/core/adaptor/impl/types.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/types.py
@@ -241,7 +241,7 @@ class SettingsBase(Base, Generic[StateT]):
 
     def get_property_state(self, prop):
         """Get the state of the ``prop`` property ."""
-        return self.sycproxy.get_state(self.syc_path + "/" + self.to_syc_name(prop))
+        return self.sycproxy.get_property_state(self.syc_path, self.to_syc_name(prop))
 
     @staticmethod
     def _print_state_helper(state, out, indent=0, indent_factor=2):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -183,6 +183,15 @@ def test_query_unset_property(dm):
     assert dm.library.expression["bob"].expression_name is None
 
 
+def test_query_unknown_property(dm):
+    dm.library.expression["bob"] = {}
+    try:
+        dm.library.expression["bob"].expression_unknown is None
+        assert False, "Expected exception not thrown"
+    except AttributeError:
+        pass
+
+
 def test_query_none_rhs_property(dm):
     dm.library.expression["bob"] = {
         "expression_name": None,

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -82,6 +82,9 @@ class SycProxy(SycProxyInterface):
     def get_state(self, path):
         return self.__state.get_state(path)
 
+    def get_property_state(self, path, name):
+        return self.__state.get_parameter(path, name)
+
     def delete(self, path):
         self.__state.delete_object(path)
 
@@ -151,6 +154,41 @@ def test_empty(dm):
 def test_create_library(dm):
     dm.library = {}
     assert dm.get_state() == {"library": {}}
+
+
+def test_create_empty_expression(dm):
+    dm.library.expression["bob"] = {}
+    assert dm.get_state() == {"library": {"expression": {"bob": {}}}}
+
+
+def test_create_empty_properties_expression(dm):
+    dm.library.expression["bob"] = {
+        "expression_name": None,
+        "expression_string": None,
+    }
+    assert dm.get_state() == {
+        "library": {
+            "expression": {
+                "bob": {
+                    "expression_name": None,
+                    "expression_string": None,
+                }
+            }
+        }
+    }
+
+
+def test_query_unset_property(dm):
+    dm.library.expression["bob"] = {}
+    assert dm.library.expression["bob"].expression_name is None
+
+
+def test_query_none_rhs_property(dm):
+    dm.library.expression["bob"] = {
+        "expression_name": None,
+        "expression_string": None,
+    }
+    assert dm.library.expression["bob"].expression_name is None
 
 
 def test_create_expression(dm):


### PR DESCRIPTION
Prior to this change, if a property did not exist in the current state, a query for it via "property path" syntax:

`value = syc.setup.solution_control.time_step_size`

would return an empty dictionary.

This is inconsistent with how System Coupling behaves and also with how existing but unset properties are represented in the state. In the case here, the property `time_step_size` could be missing entirely from the state either because `solution_control` is uninitialised or because other set-up renders `time_step_size` unavailable. (Either way, `time_step_size` is recognised as a _potentially_ available variable - an exception would be thrown if an arbitrary property name were queried.)

The cause of the issue was the implementation delegating to the System Coupling `GetState` query which, although it _mainly_ works for property paths, has the behaviour of returning an empty dictionary if the property does not exist in the state. Calling `GetParameter` has better behaviour. Given that we discriminate between object and property quieries in the calling code anyway this was a simple change.

