### PR TITLE
Dependency on ansys-api-systemcoupling modified to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,16 @@ maintainers = [
     {name = "PyAnsys developers", email = "pyansys.maintainers@ansys.com"},
 ]
 dependencies = [
-	"ansys-api-systemcoupling==0.1.0",
-        "ansys-platform-instancemanagement~=1.0",
-	"grpcio>=1.30.0",
-	"grpcio-status>=1.30.0,<1.64.2",
-	"googleapis-common-protos>=1.50.0",
-	"protobuf>=3.20.1,<4.0.0",
-	"psutil>=5.7.0",
-	"pyyaml",
-	"appdirs>=1.4.0",
-	"importlib-metadata>=4.0",
-	"matplotlib>=3.8.2",
+    "ansys-api-systemcoupling==0.2.0",
+    "ansys-platform-instancemanagement~=1.0",
+    "grpcio>=1.30.0",
+    "grpcio-status>=1.30.0,<1.64.2",
+    "googleapis-common-protos>=1.50.0",
+    "psutil>=5.7.0",
+    "pyyaml",
+    "appdirs>=1.4.0",
+    "importlib-metadata>=4.0",
+    "matplotlib>=3.8.2",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -79,7 +78,7 @@ doc = [
 ]
 style = [
 	# NB: ensure these remain synced with .pre-commit-config.yaml
-	"codespell==2.3.0", 
+	"codespell==2.3.0",
 	"flake8==7.1.0",
 ]
 tests = [


### PR DESCRIPTION
`ansys-api-systemcoupling`, the gRPC API package on which PySystemCoupling depends, has had a version update that relaxes its `protobuf` version requirements and in particular supports `protobuf 4.x`. This is now needed because the 25.1 SystemCoupling server has had the protobuf updated in the common Python package.

There was also an explicit dependency on `protobuf` mentioned in the `pyptroject.toml` here, which I don't think was needed.