### PR TITLE
API build and unit testing with 'latest' image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
         with:
           image-tag: v24.2.0
 
+      - name: Generate API for latest
+        uses: ./.github/actions/generate-api
+        with:
+          image-tag: latest
+
       - name: Clean out dist
         run: rm -rf dist
 
@@ -168,8 +173,15 @@ jobs:
         uses: ./.github/actions/unit-test
         with:
           image-tag: v24.2.0
-          upload-coverage: true
+          upload-coverage: false
 
+      - name: Unit Test latest
+        uses: ./.github/actions/unit-test
+        with:
+          image-tag: latest
+          upload-coverage: true
+        env:
+          ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
 
   docs:
     name: Build Documentation

--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -76,6 +76,12 @@ def start_container(
         f"ghcr.io/ansys/pysystem-coupling:{image_tag}",
     ] + args
 
+    license_server = os.getenv("ANSYSLMD_LICENSE_FILE")
+    if license_server:
+        idx = run_args.index("-e")
+        run_args.insert(idx, f"ANSYSLMD_LICENSE_FILE={license_server}")
+        run_args.insert(idx, "-e")
+
     if network:
         idx = run_args.index("-p")
         run_args.insert(idx, network)


### PR DESCRIPTION
Start building against a new "latest" (251) container.

Changes were needed to handle the new SyC licensing checks.