### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: "3.9"
+  MAIN_PYTHON_VERSION: "3.10"
   PACKAGE_NAME: "ansys-systemcoupling-core"
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: "Build wheelhouse and perform smoke test"
@@ -203,7 +203,7 @@ jobs:
         with:
           name: ${{ env.PACKAGE_NAME }}-artifacts
           path: dist
- 
+
       - name: Install pysystemcoupling with doc dependencies
         run: |
           wheel_name=`echo dist/*.whl`

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -24,7 +24,7 @@ the `Ansys <https://www.ansys.com/>`_ website.
 Install PySystemCoupling
 ========================
 
-The ``ansys-systemcoupling-core`` package currently supports Python 3.9 through
+The ``ansys-systemcoupling-core`` package currently supports Python 3.10 through
 Python 3.12 on Windows and Linux.
 
 Install the latest release from `PyPI <https://pypi.org/project/ansys-systemcoupling-core/>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-systemcoupling-core"
 version = "0.7.dev0"
 description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
@@ -36,7 +36,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
PyAnsys is dropping support for Python 3.9 on the next metapackage release and PyAnsys products are encouraged to follow suit.
We need to move to 3.10 as the doc build version in any case to allow Sphinx to be upgraded to v4.