### PR TITLE
Update Ansys Sphinx Theme to use new v1 release

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@ from ansys_sphinx_theme import (
     ansys_logo_white_cropped,
     get_version_match,
     latex,
-    pyansys_logo_black,
     watermark,
 )
 import sphinx_gallery
@@ -279,8 +278,8 @@ suppress_warnings = ["config.cache"]
 # -- Options for HTML output -------------------------------------------------
 html_short_title = html_title = "PySystemCoupling"
 html_theme = "ansys_sphinx_theme"
-html_logo = pyansys_logo_black
 html_theme_options = {
+    "logo": "pyansys",
     "github_url": "https://github.com/ansys/pysystem-coupling",
     "show_prev_next": False,
     "show_breadcrumbs": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classesgen = [
 	"isort==5.13.2",
 ]
 doc = [
-	"ansys-sphinx-theme==0.16.6",
+	"ansys-sphinx-theme==1.0.4",
 	"jupyter_sphinx==0.5.3",
 	"matplotlib",
 	"numpydoc==1.8.0",


### PR DESCRIPTION
Update Ansys Sphinx Theme dependency. Use latest point release from recent v1 release.

Also, follow the recommendation we have been given to switch from using `html_logo` option in the `conf.py` to using `logo` in the `html_theme_options` dictionary.