### PR TITLE
Re-enable 'test' job in workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
   test:
-    if: false
     name: Testing
     needs: [build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
During recent work on Sphinx doc generation, the `test` job in the `ci.yml` workflow definition was disabled. This was then inadvertently merged to `main`.

