### PR TITLE
MAINT: Update update-license-header version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     - id: check-github-workflows
 
 - repo: https://github.com/ansys/pre-commit-hooks
-  rev: v0.2.8
+  rev: v0.4.3
   hooks:
   - id: add-license-headers
     args:

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,13 @@
 MIT License
 
-Copyright (c) 2021 ANSYS, Inc. All rights reserved. 
+Copyright (c) 2023 - 2024 ANSYS, Inc. and/or its affiliates.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.


### PR DESCRIPTION
Pre-commit started failing locally for me on the `update-license-headers` hook. It turned out that the version being used was quite  out of date, and that updating to the latest version resolved the issue. 

Note that the LICENSE file itself that is updated in this PR was updated by runnin ght enew hook locally.