### PR TITLE
Revert "Bump sphinx-autobuild from 2024.9.19 to 2024.10.3"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ doc = [
 	"pypandoc==1.13",
 	"pytest-sphinx==0.6.3",
 	"Sphinx==8.0.2",
-	"sphinx-autobuild==2024.10.3",
+	"sphinx-autobuild==2024.9.19",
 	"sphinx-autodoc-typehints==2.4.4",
 	"sphinx-copybutton==0.5.2",
 	"sphinx-gallery==0.17.1",


### PR DESCRIPTION
Reverts ansys/pysystem-coupling#408

`main` build failed after merging. Revert to investigate.