### PR TITLE
MAINT: add new arguments needed by doc-deploy-dev action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,8 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
           doc-artifact-name: "documentation-html"
 
   release:


### PR DESCRIPTION
After a recent merge to main of a dependabot PR, the build on `main` failed, even though the PR build itself was fine. This seems to be because of new requirements of the `ansys/actions/doc-deploy-dev@v8` action for `bot-user` and `bot-email` arguments and nothing to do with the changes that were merged. The new required inputs are added in this PR.