### PR TITLE
MAINT: remove last use of v3 or upload-artifact action

### DIFF
--- a/.github/actions/generate-api/action.yml
+++ b/.github/actions/generate-api/action.yml
@@ -6,6 +6,7 @@ inputs:
   image-tag:
     description: 'Docker image tag for version'
     required: true
+    type: string
 
 runs:
   using: "composite"

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Upload test coverage
       if: ${{ inputs.upload-coverage }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HTML-coverage-syc
         path: cov_html

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -37,3 +37,4 @@ runs:
         name: HTML-coverage-syc
         path: cov_html
         retention-days: 7
+        overwrite: true

--- a/.github/actions/unit-test/action.yml
+++ b/.github/actions/unit-test/action.yml
@@ -6,9 +6,11 @@ inputs:
   image-tag:
     description: 'Docker image tag for version'
     required: true
+    type: string
   upload-coverage:
     description: 'Whether to upload coverage data to Codecov'
     required: true
+    type: boolean
 
 runs:
   using: "composite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: "3.10"
+  MAIN_PYTHON_VERSION: "3.11"
   PACKAGE_NAME: "ansys-systemcoupling-core"
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -239,6 +239,9 @@ def _reset_example(gallery_conf, fname: str, when: str):
                 ["docker", "compose", "-f", "mapdl-docker-compose.yml", "down"]
             )
             print("MAPDL container removed")
+        # Add sleep after example to see if it helps with grpcs errors seen after everything
+        # should have finished.
+        time.sleep(10)
 
 
 rst_epilog = make_replacements_for_versioned_class_refs(("CASE", "SETUP", "SOLUTION"))


### PR DESCRIPTION
Using v3 of upload-artifact now causes an error in the workflow.

There is one remaining use. Upgrade it to v4.
