### PR TITLE
MAINT: support Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: "3.11"
+  MAIN_PYTHON_VERSION: "3.12"
   PACKAGE_NAME: "ansys-systemcoupling-core"
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: "Build wheelhouse and perform smoke test"

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/README.rst
+++ b/README.rst
@@ -87,11 +87,13 @@ function. This will affect which ``AWP_ROOT<version>`` environment variable is e
 
    There is an issue with the 25 R1 release of Ansys System Coupling that prevents it from
    working in the gRPC server mode that is needed to support PySystemCoupling. A small patch
-   may be applied to some of the Python files in the System Coupling installation to allow
-   it to work with the current release of PySystemCoupling. This is provided in the `patches/`
-   directory of this repository. Otherwise, PySystemCoupling should be used with an earlier
-   release of System Coupling by setting the environment variable ``AWP_ROOT`` or specifying
-   the version number as an argument to the ``launch()`` function.
+   is available that may be applied to some of the Python files in the System Coupling
+   installation. This is provided in the `patches/` directory of this repository and will
+   allow System Coupling to work with the current release of PySystemCoupling.
+
+   Otherwise, PySystemCoupling should be used with an earlier release of System Coupling by
+   setting the environment variable ``AWP_ROOT`` or specifying the version number as an
+   argument to the ``launch()`` function.
 
 
 The System Coupling API is exposed to PySystemCoupling in two forms:

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ function. This will affect which ``AWP_ROOT<version>`` environment variable is e
    **WARNING**
 
    There is an issue with the 25 R1 release of Ansys System Coupling that prevents it from
-   working in the gRPC server mode that is needed to support PySystemCoupling. A small patch
+   working in the gRPC server mode on which PySystemCoupling depends. A small patch
    is available that may be applied to some of the Python files in the System Coupling
    installation. This is provided in the `patches/` directory of this repository and will
    allow System Coupling to work with the current release of PySystemCoupling.

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ function. This will affect which ``AWP_ROOT<version>`` environment variable is e
    There is an issue with the 25 R1 release of Ansys System Coupling that prevents it from
    working in the gRPC server mode on which PySystemCoupling depends. A small patch
    is available that may be applied to some of the Python files in the System Coupling
-   installation. This is provided in the `patches/` directory of this repository and will
+   installation. This is provided in the ``patches/`` directory of this repository and will
    allow System Coupling to work with the current release of PySystemCoupling.
 
    Otherwise, PySystemCoupling should be used with an earlier release of System Coupling by

--- a/README.rst
+++ b/README.rst
@@ -83,7 +83,7 @@ In a standard user installation, the expectation is that only ``AWP_ROOT251`` is
 (It is also possible to provide a different version number as an argument to the ``launch()``
 function. This will affect which ``AWP_ROOT<version>`` environment variable is examined.)
 
-.. warning::
+   **WARNING**
 
    There is an issue with the 25 R1 release of Ansys System Coupling that prevents it from
    working in the gRPC server mode that is needed to support PySystemCoupling. A small patch
@@ -105,7 +105,7 @@ familiar with System Coupling, adjusting to this form, which is the recommended 
 However, if you are transitioning existing scripts, the native System Coupling API is made available
 as a convenience.
 
-.. note::
+   **Note**
 
    While most commands should work as expected via the native System Coupling API,
    no guarantees can be given because of the nature of how it is exposed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-systemcoupling-core"
 version = "0.9.dev0"
 description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 license = {file = "LICENSE"}
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bump supported Python versions to 3.13.
Trying to make 3.13 the "main" version for doc builds etc. fails because of issues with satisfying all dependencies. It is still worth proceeding with the support for 3.13 but, for now, the "main" version has been bumped to 3.12.

Addresses #433.