### PR TITLE
MAINT: Remove the ansys-dpf-core dependency as it is no longer used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ doc = [
 
 	# pyansys dependencies for sphinx gallery examples
 	"ansys-fluent-core==0.29.0",
-	"ansys-dpf-core==0.13.4",
 	"ansys-mapdl-core==0.69.3",
 ]
 style = [


### PR DESCRIPTION
`ans-dpf-core` was listed as a Sphinx Gallery dependency as it used to be used in one of the gallery examples. It is no longer used so can be removed from the `pyproject.toml` file.