### PR TITLE
FIX: revert bump of ansys-fluent-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ doc = [
 	"sphinxemoji==0.3.1",
 
 	# pyansys dependencies for sphinx gallery examples
-	"ansys-fluent-core==0.30.0",
+	"ansys-fluent-core==0.29.0",
 	"ansys-mapdl-core==0.69.3",
 ]
 style = [


### PR DESCRIPTION
Builds on main seemed to started failing when this bump was merged. 

It is not clear why but revert for now and check that builds pass again.