### PR TITLE
Revert "Bump ansys-fluent-core from 0.29.0 to 0.30.2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ doc = [
 	"sphinxemoji==0.3.1",
 
 	# pyansys dependencies for sphinx gallery examples
-	"ansys-fluent-core==0.30.2",
+	"ansys-fluent-core==0.29.0",
 	"ansys-mapdl-core==0.69.3",
 ]
 style = [


### PR DESCRIPTION
Reverts ansys/pysystem-coupling#468

For some reason not fully understood, this update fails the doc build when merged to main, though it passes on the branch.

