### PR TITLE
FIX:  handling of named objects in set_state

### DIFF
--- a/src/ansys/systemcoupling/core/util/state_keys.py
+++ b/src/ansys/systemcoupling/core/util/state_keys.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import copy
+from typing import Any, Dict, Set
 
 
 def adapt_native_named_object_keys(state):
@@ -74,7 +75,9 @@ def adapt_native_named_object_keys_in_place(state):
         del state[k]
 
 
-def adapt_client_named_object_keys(state, level_type_map):
+def adapt_client_named_object_keys(
+    state: Dict[str, Any], level_type_map: Dict[int, Set[str]], start_level: int = 0
+) -> Dict[str, Any]:
     """Transform a System Coupling client-style nested state dictionary
     to an equivalent native format.
 
@@ -89,12 +92,18 @@ def adapt_client_named_object_keys(state, level_type_map):
 
     Parameters
     ----------
+    state: dict
+        The nested state dictionary to transform to the native format.
     level_type_map: dict
         Dictionary from the integer nest level (0-based) to sets of
         named object types at this level. Note that the level is
         the data model level. This means it does not include the extra
         levels introduced by the client-side format but more closely
         aligns with the target native format.
+    start_level: int, optional
+        If state is a sub-state of a larger state, and the level_type_map
+        is for the larger state, then this parameter can be used to
+        provide a starting level for the transformation.
     """
 
     def do_adapt(s, level=0):
@@ -110,4 +119,4 @@ def adapt_client_named_object_keys(state, level_type_map):
                 state_out[id] = copy.copy(sub_state)
         return state_out
 
-    return do_adapt(state)
+    return do_adapt(state, level=start_level)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -79,6 +79,34 @@ def test_set_and_get() -> None:
         assert setup.library.expression.get_object_names() == ["expr1"]
 
 
+def test_set_and_get_state() -> None:
+    with pysystemcoupling.launch_container() as syc:
+        assert syc.ping()
+
+        # This is a variation on test_get_and_set that focuses on
+        # get_state and set_state. An issue had been found with the
+        # handling of named objects in the submitted state
+        # dictionary, which this test is designed to exercise.
+        setup = syc.setup
+        expr1 = setup.library.expression.create("expr1")
+
+        state = setup.get_state()
+        assert "library" in state
+
+        state["library"]["expression"]["expr1"]["expression_name"] = "expr_1"
+        setup.set_state(state)
+
+        assert expr1.expression_name == "expr_1"
+
+        state = setup.library.get_state()
+        assert "expression" in state
+
+        state["expression"]["expr1"]["expression_string"] = "2 * x"
+        setup.library.set_state(state)
+
+        assert expr1.expression_string == "2 * x"
+
+
 def test_more_datamodel_operations() -> None:
     with pysystemcoupling.launch_container() as syc:
         assert syc.ping()


### PR DESCRIPTION
Most setting of state in PySystemCoupling - in examples and tutorials and in general practice - is done via the attribute API whereby individual settings are made via path-like chained attributes. For example:

`syc.setup.coupling_interface["intf-1"].target_side = "One"`

It is possible to set state via a dictionary assigned at different levels. For example:

`syc.setup.coupling_interface["intf-1"].set_state({"target_side": "One"})`

or, from a higher level:

`syc.setup.set_state({"coupling_interface":{"intf-1":{"target_side": "One"}}})`

(This is most likely to be useful if multiple settings are made at once via the state dictionary.)

In fact, before the current PR, the second example above did not work. This is because, when this state dictionary is adapted for submission to System Coupling, as well as mapping the names in the state dictionary to their native SystemCoupling counterparts, the representation of named objects in the dictionary also needs to be asjusted and this was not being done.

In PySystemCoupling, named objects are represented in a state dictionary by two levels. One is for the type of named object (`"coupling_interface"` in the above) and the other is the named instances themselved, keyed by their names (as in the `"intf-1"` entry above). In SystemCoupling meanwhile, each named object instance has a single level entry keyed by something like `"CouplingInterface:intf-1"`). It is the transformation between these representations that was missing.

It seems that this was anticipated because a helper function already exists for this, but it was not applied where it needs to be. 











