### PR TITLE
MAINT: start targeting 25.2

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -41,16 +41,16 @@ after the preceding steps for cloning and installing the package.
 
 The generated code is written to the directory ``src/ansys/systemcoupling/core/adaptor/api_<version>``,
 where ``<version>`` is the version of the System Coupling instance that was run in the background
-by the generation script. For example, the version ``25_1`` corresponds to the System Coupling 2024 R2.
-The default is ``25_1``, which means that this release of System Coupling is expected to be at the
-installation location given by the ``AWP_ROOT251`` environment variable.
+by the generation script. For example, the version ``25_2`` corresponds to System Coupling 2025 R2.
+The default is ``25_2``, which means that this release of System Coupling is expected to be at the
+installation location given by the ``AWP_ROOT252`` environment variable.
 
 You can override the default behavior and run a different version, and generate the API classes for
 this different version, by setting either the ``SYSC_ROOT`` environment variable to point to the
 root directory of your System Coupling installation or the ``AWP_ROOT`` environment variable to
 point to the root of an Ansys installation. If ``SYSC_ROOT`` and ``AWP_ROOT`` environment variables
 are both set, the former takes priority. Additionally, both of these environment variables take priority
-over the ``AWP_ROOT251`` environment variable.
+over the ``AWP_ROOT252`` environment variable.
 
 
 Build documentation
@@ -63,7 +63,7 @@ Because multiple versions of the API classes can exist, you must set the ``PYSYC
 environment variable to tell the documentation build which version to use. Given that there is
 no default for this environment variable, you *must* set it. The value should be a string in the
 same form as the ``<version>`` component of the ``api_<version>`` directory. For example,
-"24_1".
+"25_2".
 
 With this variable set, run these commands to build the documentation:
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -12,7 +12,7 @@ PySystemCoupling supports Ansys System Coupling version 2023 R1 and later.
 
    The detailed documentation, particularly that in the :ref:`ref_index_api`
    section, is based on the *current* official Ansys release at this release of
-   PySystemCoupling. This is **2025 R1**. Although the majority of it does not change
+   PySystemCoupling. This is **2025 R2**. Although the majority of it does not change
    between releases, you should consult the API documentation for an earlier
    applicable release of PySystemCoupling if you are running with an older System
    Coupling version and want to be sure of the details.

--- a/src/ansys/systemcoupling/core/__init__.py
+++ b/src/ansys/systemcoupling/core/__init__.py
@@ -72,7 +72,7 @@ def launch(
         (The forms ``"24.1"`` and ``"24_1"`` are also acceptable.)
         The version will be sought in the standard installation location. The
         default is ``None``, which is equivalent to specifying
-        ``"251"`` ("2025 R1" release), unless either of the environment
+        ``"252"`` ("2025 R2" release), unless either of the environment
         variables ``SYSC_ROOT`` or ``AWP_ROOT`` has been set. It is considered
         to be an error if either these is set *and* ``version`` is provided.
     start_output: bool, optional

--- a/src/ansys/systemcoupling/core/syc_version.py
+++ b/src/ansys/systemcoupling/core/syc_version.py
@@ -25,7 +25,7 @@ from typing import Tuple
 # Define constants relating to the default/current version of System Coupling
 
 SYC_MAJOR_VERSION = 25
-SYC_MINOR_VERSION = 1
+SYC_MINOR_VERSION = 2
 
 SYC_VERSION_CONCAT = f"{SYC_MAJOR_VERSION}{SYC_MINOR_VERSION}"
 SYC_VERSION_DOT = f"{SYC_MAJOR_VERSION}.{SYC_MINOR_VERSION}"


### PR DESCRIPTION
Various changes, including default `AWP_ROOT*` environment variable, to start targeting 25.2.
