### PR TITLE
MAINT: revert fluent to previous version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ doc = [
 	"sphinxemoji==0.3.1",
 
 	# pyansys dependencies for sphinx gallery examples
-	"ansys-fluent-core==0.34.0",
+	"ansys-fluent-core==0.33.0",
 	"ansys-mapdl-core==0.70.2",
 ]
 style = [


### PR DESCRIPTION
Builds on main have failed since this upgrade though the issue isn't obviously with fluent.