### PR TITLE
fix: always write license logs to working dir

### DIFF
--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -85,9 +85,14 @@ def start_container(
         idx = run_args.index("-p")
         run_args.insert(idx, container_user)
         run_args.insert(idx, "--user")
-        # Licensing can't log to default location if user is not the default 'root'
-        run_args.insert(idx, f"ANSYSLC_APPLOGDIR={mounted_to}")
-        run_args.insert(idx, "-e")
+
+    # This was always definitely necessary in the SYC_CONTAINER_USER case
+    # because licensing can't log to the default location if user is
+    # not the default 'root'. However it seems that logging might be an
+    # issue in other cases too so set the log dir to working dir always.
+    idx = run_args.index("-p")
+    run_args.insert(idx, f"ANSYSLC_APPLOGDIR={mounted_to}")
+    run_args.insert(idx, "-e")
 
     license_server = os.getenv("ANSYSLMD_LICENSE_FILE")
     if license_server:


### PR DESCRIPTION
There was a previous issue when we were running containers with the `--user` flag where licensing failed because there was no home directory in the container in these cases, and that was where licensing was trying to write its logs. By setting `ANSYSLC_APPLOGDIR` to the working directory, the issue was resolved because licensing would use this as its log directory instead. However, in the cases where we weren't setting `--user`, we left the default behaviour.

There have been recent issues in doc builds and tests where license checks have failed regularly but intermittently. In trying to debug this, `ANSYS_APPLOGDIR` was set (to the working directory) in _all_ container cases so that it would be easier to see logs. This seems to have had the effect of fixing the issues so that change is being made here.