### PR TITLE
chore: bump version after release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,13 +391,16 @@ jobs:
           files: |
             ./**/*.whl
             ./**/*.tar.gz
-            documentation-html 
+            documentation-html
 
   upload_docs_release:
     name: "Upload release documentation"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: [release]
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@21c9de9bee9692173780696d4a39964f20b9cfa3 # v10.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-systemcoupling-core"
-version = "0.11.dev0"
+version = "0.12.dev0"
 description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
 requires-python = ">=3.10,<3.14"


### PR DESCRIPTION
* Bump the dev version to 0.12.dev0 following the 0.11.x releases.
* Fix an issue found in the upload release docs job. Following recent security changes on the workflow, some jobs needed to have explicit permissions added. This was missed because it is only run when a release is made.
