### PR TITLE
FIX: fix setting of uds-id

### DIFF
--- a/src/ansys/systemcoupling/core/client/grpc_transport.py
+++ b/src/ansys/systemcoupling/core/client/grpc_transport.py
@@ -282,6 +282,7 @@ class StartupAndConnectionInfo:
                     if self._is_uds_supported()
                     else _TransportMode.WNUA
                 )
+                # If UDS, uds_id will be set later if not already set
             case ConnectionType.UNIX_DOMAIN_SOCKETS:
                 if not self._is_uds_supported():
                     raise RuntimeError(
@@ -293,8 +294,7 @@ class StartupAndConnectionInfo:
                         "UDS transport only supports localhost connections."
                     )
                 options.transport_mode = _TransportMode.UDS
-                if not options.uds_id:
-                    options.uds_id = uuid4().hex
+                # uds_id will be set later if not already set
             case ConnectionType.WINDOWS_NAMED_USER_AUTHENTICATION:
                 if not _IS_WINDOWS:
                     raise ValueError(


### PR DESCRIPTION
The intent is that PySystemCoupling should always provide the `--uds-id` command line argument to SyC when using UDS transport mode, If it has not been explicitly provided as an option, an ID is generated. However, the ID generation was being skipped in the case where UDS  was implicitly derived from the default `SECURE_LOCAL` connection type. This led to a mismatch between PySystemCoupling, which was deriving a socket filename using `f"systemcoupling-{options.uds_id}.sock"` where `options.uds_id` is unset, and SystemCoupling, which was not receiving a `--uds-id` argument and assuming the socket file name was `"systemcoupling.sock"`.