### PR TITLE
fix: add explicit units lib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ doc = [
 
 	# pyansys dependencies for sphinx gallery examples
 	"ansys-fluent-core==0.35.0",
+	# ... temporary to fix fluent runtime error: 
+	"ansys-units==0.9.1", 
 	"ansys-mapdl-core==0.71.3",
 ]
 style = [


### PR DESCRIPTION
An error has started appearing in all doc builds at the point where pyfluent is imported:

`AttributeError: type object 'mesh' has no attribute 'STORED_CELL_PARTITIION'. Did you mean: 'STORED_CELL_PARTITION'?`

The suggested fix is to install a specific version of the units library until this issue is fixed properly.