### PR TITLE
style: fix broken style checks

### DIFF
--- a/examples/00-systemcoupling/cht_pipe.py
+++ b/examples/00-systemcoupling/cht_pipe.py
@@ -51,6 +51,7 @@ at an initial temperature of 300K while the outer wall of the pipe is at 350K.
 
 
 """
+
 # %%
 # Import modules, download files, launch products
 # -----------------------------------------------

--- a/examples/00-systemcoupling/oscillating_plate.py
+++ b/examples/00-systemcoupling/oscillating_plate.py
@@ -53,6 +53,7 @@ air are simulated for a few oscillations to allow an examination of the
 motion of the plate as it is damped.
 
 """
+
 # %%
 # Import modules, download files, launch products
 # -----------------------------------------------

--- a/examples/00-systemcoupling/turek_hron_fsi2.py
+++ b/examples/00-systemcoupling/turek_hron_fsi2.py
@@ -53,6 +53,7 @@ allow an examination of the motion of the beam as it starts vibrating due to
 vortices shedded by the rigid cylinder.
 
 """
+
 # %%
 # Import modules, download files, launch products
 # -----------------------------------------------

--- a/src/ansys/systemcoupling/core/client/grpc_transport.py
+++ b/src/ansys/systemcoupling/core/client/grpc_transport.py
@@ -88,7 +88,7 @@ class ConnectionType(Enum):
 class _TransportMode(str, Enum):
     """Enum containing the different modes of connection."""
 
-    (INSECURE, UDS, MTLS, WNUA) = ("insecure", "uds", "mtls", "wnua")
+    INSECURE, UDS, MTLS, WNUA = ("insecure", "uds", "mtls", "wnua")
 
 
 class StartupArgumentCategory(Enum):


### PR DESCRIPTION
An update of black in a dependabot PR broke the style check task. Not clear why it did not break in the dependabot PR and only when it was merged to main.