### PR TITLE
doc: small update to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,8 @@ certain environment variables. The System Coupling installation is found
 by examining the following environment variables in this order:
 
 * ``SYSC_ROOT`` - this is assumed to point directly to a root System Coupling folder.
-* ``AWP_ROOT`` - this is assumed to point to a root Ansys folder, under which a ``SystemCoupling`` folder is present.
+* ``AWP_ROOT`` - this is assumed to point to a root Ansys folder, under which a
+  ``SystemCoupling`` folder is present.
 * ``AWP_ROOT<NNN>`` - these are standard environment variables that are automatically
   set by Ansys installations, where ``<NNN>`` is a version number, such as 252 for
   Ansys 25 R2. As noted above, if multiple such variables are set, the one with the


### PR DESCRIPTION
Following recent changes in how a System Coupling installation is located, adjust the README to put more emphasis on the default behaviour of using the `AWP_ROOTNNN` variables.