### PR TITLE
maint: Prepare for release targeting v261

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,14 +379,17 @@ jobs:
           export SYC_CONTAINER_USER=$(id -u):$(id -g)
 
           # On the first attempt do a full clean build.
-          # On retries, deliberately skip 'make clean': this preserves the
-          # sphinx-gallery .md5 files in doc/source/examples/ so that only
-          # examples that actually failed are re-run instead of the whole gallery.
+          # On retries, clean only build artefacts while preserving
+          # doc/source/examples so sphinx-gallery .md5 files remain available.
+          # This allows only failed examples to re-run while avoiding stale
+          # files in doc/_build causing static asset copy conflicts.
           for attempt in 1 2 3; do
             if [ "$attempt" -eq 1 ]; then
               make -C doc clean
             else
-              echo "Retrying docs build (attempt ${attempt}) without full clean so only failed examples re-run..."
+              echo "Retrying docs build (attempt ${attempt}) with partial clean to preserve gallery md5 files..."
+              rm -rf doc/_build/*
+              find doc -type d -name "_autosummary" -exec rm -rf {} +
               sleep 10
             fi
             if make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,23 @@ jobs:
         env:
           GRPCIO_VERSION_261: ${{ env.GRPCIO_VERSION_261 }}
 
+      - name: Diagnostic - effective gRPC options for v26.1 tests
+        run: |
+          python - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("PYSYC_GRPC_CHANNEL_OPTIONS_JSON", "")
+          print(f"PYSYC_GRPC_CHANNEL_OPTIONS_JSON={raw}")
+          try:
+              parsed = json.loads(raw) if raw else {}
+          except Exception as exc:
+              parsed = {"_parse_error": str(exc)}
+          print(f"parsed_grpc_options={parsed}")
+          PY
+        env:
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+
       - name: Unit Test v26.1.0
         uses: ./.github/actions/unit-test
         with:
@@ -258,8 +275,7 @@ jobs:
           upload-coverage: true
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
-          #PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 20000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 7200000, "grpc.keepalive_timeout_ms": 90000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
 
       #- name: Unit Test latest
       #  uses: ./.github/actions/unit-test
@@ -335,6 +351,23 @@ jobs:
           FLUENT_IMAGE_VERSION: ${{ env.FLUENT_IMAGE_VERSION }}
           MAPDL_IMAGE_VESRION: ${{ env.MAPDL_IMAGE_VERSION }}
 
+      - name: Diagnostic - effective gRPC options for docs build
+        run: |
+          python - <<'PY'
+          import json
+          import os
+
+          raw = os.environ.get("PYSYC_GRPC_CHANNEL_OPTIONS_JSON", "")
+          print(f"PYSYC_GRPC_CHANNEL_OPTIONS_JSON={raw}")
+          try:
+              parsed = json.loads(raw) if raw else {}
+          except Exception as exc:
+              parsed = {"_parse_error": str(exc)}
+          print(f"parsed_grpc_options={parsed}")
+          PY
+        env:
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+
       - name: Build HTML
         run: |
           set -o pipefail
@@ -352,8 +385,7 @@ jobs:
         env:
           PYSYC_DOC_BUILD_VERSION: ${{ env.DOC_BUILD_SYC_VERSION }}
           PYSYC_BUILD_SPHINX_GALLERY: 1
-          #PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 20000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 7200000, "grpc.keepalive_timeout_ms": 90000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           SYC_LAUNCH_CONTAINER: 1
           SYC_IMAGE_TAG: ${{ env.SYC_IMAGE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,9 +395,9 @@ jobs:
             if make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then
               break
             fi
-            if grep -q 'grpc_details=ping timeout' build-html.log; then
+            if grep -q 'problems encountered when running the examples' build-html.log; then
               if [ "$attempt" -eq 3 ]; then
-                echo "Docs build failed with gRPC ping timeout after ${attempt} attempts."
+                echo "Docs build failed with gallery example errors after ${attempt} attempts."
                 exit 1
               fi
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,14 @@ env:
   # try to avoid ping timeout issues. This is mainly seen in the long-running
   # "solve" RPC. Review whether this remains necessary with future versions.
   GRPCIO_VERSION_261: "1.81.1"
-  # gRPC channel options for v26.1: Moderate keepalive strategy balancing client and
-  # server expectations. Reduces aggressive pinging during long-running solve() RPC while
-  # respecting server ping-strike timeouts. Key philosophy:
-  # 1. Client-initiated keepalive every 90 seconds (moderate, not aggressive 30s or extreme ~24 days)
-  # 2. Only ping when waiting on an active RPC or if connection becomes idle
-  # 3. Conservative 5-minute spacing between individual pings when they do occur
-  # 4. Patient with ping responses (no timeout), respects server's ping expectations
-  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 90000, "grpc.keepalive_timeout_ms": 2147483647, "grpc.keepalive_permit_without_calls": 0, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 300000, "grpc.http2.min_ping_interval_without_data_ms": 300000}'
+  # gRPC channel options for v26.1: Balanced keepalive strategy for long-running solve() RPC.
+  # Keepalive is intentionally moderate (90s) and the min ping intervals are aligned to avoid
+  # internally throttling the intended cadence, while still avoiding aggressive pinging.
+  # 1. Keepalive every 90 seconds (middle ground between 30s and near-disabled keepalive)
+  # 2. Do not ping without calls (only when activity requires it)
+  # 3. Align min ping intervals to 90 seconds to avoid 5-minute throttling effects
+  # 4. Keep ping response timeout permissive to avoid false negatives on long solves
+  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 90000, "grpc.keepalive_timeout_ms": 2147483647, "grpc.keepalive_permit_without_calls": 0, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 90000, "grpc.http2.min_ping_interval_without_data_ms": 90000}'
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ env:
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
   DOC_BUILD_SYC_VERSION: 26_1
+  # Intermittent gRPC ping timeout issues seen with the 26.1 container.
+  # Pin the gRPC version for 261 doc and test and set channel options to
+  # try to avoid ping timeout issues. This is mainly seen in the long-running
+  # "solve" RPC. Review whether this remains necessary with future versions.
   GRPCIO_VERSION_261: "1.81.1"
+  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"
@@ -266,7 +271,7 @@ jobs:
           print(f"parsed_grpc_options={parsed}")
           PY
         env:
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
 
       - name: Unit Test v26.1.0
         uses: ./.github/actions/unit-test
@@ -275,7 +280,7 @@ jobs:
           upload-coverage: true
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
 
       #- name: Unit Test latest
       #  uses: ./.github/actions/unit-test
@@ -366,7 +371,7 @@ jobs:
           print(f"parsed_grpc_options={parsed}")
           PY
         env:
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
 
       - name: Build HTML
         run: |
@@ -399,7 +404,7 @@ jobs:
         env:
           PYSYC_DOC_BUILD_VERSION: ${{ env.DOC_BUILD_SYC_VERSION }}
           PYSYC_BUILD_SPHINX_GALLERY: 1
-          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           SYC_LAUNCH_CONTAINER: 1
           SYC_IMAGE_TAG: ${{ env.SYC_IMAGE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
   DOC_BUILD_SYC_VERSION: 26_1
+  GRPCIO_VERSION_261: "1.73.1"
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"
@@ -236,6 +237,18 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
 
+      - name: Pin grpcio for v26.1 tests
+        run: |
+          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} > /dev/null
+          python - <<'PY'
+          import grpc
+          import grpc_status
+          print(f"grpcio version: {grpc.__version__}")
+          print(f"grpcio-status module: {grpc_status.__name__}")
+          PY
+        env:
+          GRPCIO_VERSION_261: ${{ env.GRPCIO_VERSION_261 }}
+
       - name: Unit Test v26.1.0
         uses: ./.github/actions/unit-test
         with:
@@ -281,6 +294,18 @@ jobs:
         run: |
           wheel_name=`echo dist/*.whl`
           pip install -q --force-reinstall ${wheel_name}[doc] > /dev/null
+
+      - name: Pin grpcio for docs build (v26.1)
+        run: |
+          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} > /dev/null
+          python - <<'PY'
+          import grpc
+          import grpc_status
+          print(f"grpcio version: {grpc.__version__}")
+          print(f"grpcio-status module: {grpc_status.__name__}")
+          PY
+        env:
+          GRPCIO_VERSION_261: ${{ env.GRPCIO_VERSION_261 }}
 
       - name: Docker Login
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   PACKAGE_NAME: "ansys-systemcoupling-core"
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
-  DOC_BUILD_SYC_VERSION: 25_2
+  DOC_BUILD_SYC_VERSION: 26_1
   FLUENT_IMAGE_VERSION: "v25.2.0"
-  SYC_IMAGE_VERSION: "v25.2.0-sp03"
+  SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"
 
 permissions: {} # Zero permissions can be granted at the workflow level if not all jobs require permissions.
@@ -131,16 +131,6 @@ jobs:
           username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           password: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
 
-      - name: Generate API for v231
-        uses: ./.github/actions/generate-api
-        with:
-          image-tag: v23.1.0
-
-      - name: Generate API for v232
-        uses: ./.github/actions/generate-api
-        with:
-          image-tag: v23.2.0
-
       - name: Generate API for v241
         uses: ./.github/actions/generate-api
         with:
@@ -160,6 +150,11 @@ jobs:
         uses: ./.github/actions/generate-api
         with:
           image-tag: v25.2.0-sp03
+
+      - name: Generate API for v261
+        uses: ./.github/actions/generate-api
+        with:
+          image-tag: v26.1.0
 
       #- name: Generate API for latest
       #  uses: ./.github/actions/generate-api
@@ -213,18 +208,6 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
 
-      - name: Unit Test v23.1.0
-        uses: ./.github/actions/unit-test
-        with:
-          image-tag: v23.1.0
-          upload-coverage: false
-
-      - name: Unit Test v23.2.0
-        uses: ./.github/actions/unit-test
-        with:
-          image-tag: v23.2.0
-          upload-coverage: false
-
       - name: Unit Test v24.1.0
         uses: ./.github/actions/unit-test
         with:
@@ -249,9 +232,19 @@ jobs:
         uses: ./.github/actions/unit-test
         with:
           image-tag: v25.2.0-sp03
+          upload-coverage: false
+        env:
+          ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
+
+      - name: Unit Test v26.1.0
+        uses: ./.github/actions/unit-test
+        with:
+          image-tag: v26.1.0
           upload-coverage: true
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
+          #PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 20000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 7200000, "grpc.keepalive_timeout_ms": 90000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0}'
 
       #- name: Unit Test latest
       #  uses: ./.github/actions/unit-test
@@ -315,12 +308,23 @@ jobs:
 
       - name: Build HTML
         run: |
+          set -o pipefail
           export SYC_CONTAINER_USER=$(id -u):$(id -g)
           make -C doc clean
-          make -C doc html SPHINXERRWARN="-W"
+          if ! make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then
+            if grep -q 'grpc_details=ping timeout' build-html.log; then
+              echo "Detected gRPC ping timeout during docs build; retrying once..."
+              make -C doc clean
+              make -C doc html SPHINXERRWARN="-W"
+            else
+              exit 1
+            fi
+          fi
         env:
           PYSYC_DOC_BUILD_VERSION: ${{ env.DOC_BUILD_SYC_VERSION }}
           PYSYC_BUILD_SPHINX_GALLERY: 1
+          #PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 20000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: '{"grpc.keepalive_time_ms": 7200000, "grpc.keepalive_timeout_ms": 90000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0}'
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           SYC_LAUNCH_CONTAINER: 1
           SYC_IMAGE_TAG: ${{ env.SYC_IMAGE_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,14 @@ env:
   # try to avoid ping timeout issues. This is mainly seen in the long-running
   # "solve" RPC. Review whether this remains necessary with future versions.
   GRPCIO_VERSION_261: "1.81.1"
-  # gRPC channel options for v26.1: Passive keepalive strategy to prevent ping
-  # timeouts during long-running solve() RPC calls. Key philosophy:
-  # 1. Virtually disable client-initiated pinging (~24 days interval)
-  # 2. Only ping when waiting on an active RPC, not when idle
-  # 3. Use conservative 5-minute spacing to align with server defaults
-  # 4. Don't timeout waiting for ping responses
-  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 2147483647, "grpc.keepalive_timeout_ms": 2147483647, "grpc.keepalive_permit_without_calls": 0, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 300000, "grpc.http2.min_ping_interval_without_data_ms": 300000}'
+  # gRPC channel options for v26.1: Moderate keepalive strategy balancing client and
+  # server expectations. Reduces aggressive pinging during long-running solve() RPC while
+  # respecting server ping-strike timeouts. Key philosophy:
+  # 1. Client-initiated keepalive every 90 seconds (moderate, not aggressive 30s or extreme ~24 days)
+  # 2. Only ping when waiting on an active RPC or if connection becomes idle
+  # 3. Conservative 5-minute spacing between individual pings when they do occur
+  # 4. Patient with ping responses (no timeout), respects server's ping expectations
+  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 90000, "grpc.keepalive_timeout_ms": 2147483647, "grpc.keepalive_permit_without_calls": 0, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 300000, "grpc.http2.min_ping_interval_without_data_ms": 300000}'
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,9 @@ jobs:
           # doc/source/examples so sphinx-gallery .md5 files remain available.
           # This allows only failed examples to re-run while avoiding stale
           # files in doc/_build causing static asset copy conflicts.
+          should_retry_regex='problems encountered when running the examples|EOFError|ev_epoll1_linux\.cc|grpc_details=|StatusCode\.UNAVAILABLE|Stream removed'
           for attempt in 1 2 3; do
+            attempt_log="build-html-attempt-${attempt}.log"
             if [ "$attempt" -eq 1 ]; then
               make -C doc clean
             else
@@ -392,12 +394,14 @@ jobs:
               find doc -type d -name "_autosummary" -exec rm -rf {} +
               sleep 10
             fi
-            if make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then
+            if make -C doc html SPHINXOPTS="-j 1" SPHINXERRWARN="-W" 2>&1 | tee "${attempt_log}"; then
+              cp "${attempt_log}" build-html.log
               break
             fi
-            if grep -q 'problems encountered when running the examples' build-html.log; then
+            cp "${attempt_log}" build-html.log
+            if grep -Eq "${should_retry_regex}" "${attempt_log}"; then
               if [ "$attempt" -eq 3 ]; then
-                echo "Docs build failed with gallery example errors after ${attempt} attempts."
+                echo "Docs build failed after ${attempt} attempts with retry-eligible transient errors."
                 exit 1
               fi
             else
@@ -417,6 +421,36 @@ jobs:
           PYMAPDL_PORT: "50053"
           DOCKER_IMAGE: ghcr.io/ansys/mapdl:${{ env.MAPDL_IMAGE_VERSION }}
           PYMAPDL_GRPC_TRANSPORT: "insecure"
+
+      - name: Collect docs failure diagnostics
+        if: failure()
+        run: |
+          mkdir -p ci-logs/docker
+
+          cp -f build-html.log ci-logs/ 2>/dev/null || true
+          cp -f build-html-attempt-*.log ci-logs/ 2>/dev/null || true
+
+          docker ps -a --format '{{.ID}} {{.Image}} {{.Names}} {{.Status}}' > ci-logs/docker/containers.txt || true
+
+          docker ps -a --format '{{.ID}} {{.Image}} {{.Names}}' | while read -r cid image name; do
+            if echo "${image} ${name}" | grep -Eiq 'pysystem-coupling|pyfluent|mapdl|fluent|systemcoupling'; then
+              safe_name=$(echo "${name}" | tr '/: ' '___')
+              docker logs "${cid}" > "ci-logs/docker/${safe_name}.log" 2>&1 || true
+              docker inspect "${cid}" > "ci-logs/docker/${safe_name}.inspect.json" 2>/dev/null || true
+            fi
+          done
+
+      - name: Upload docs diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-diagnostics
+          path: |
+            build-html.log
+            build-html-attempt-*.log
+            ci-logs/**
+          retention-days: 7
+          if-no-files-found: warn
 
       #- name: Build PDF Documentation
       #  run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,16 +372,30 @@ jobs:
         run: |
           set -o pipefail
           export SYC_CONTAINER_USER=$(id -u):$(id -g)
-          make -C doc clean
-          if ! make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then
-            if grep -q 'grpc_details=ping timeout' build-html.log; then
-              echo "Detected gRPC ping timeout during docs build; retrying once..."
+
+          # On the first attempt do a full clean build.
+          # On retries, deliberately skip 'make clean': this preserves the
+          # sphinx-gallery .md5 files in doc/source/examples/ so that only
+          # examples that actually failed are re-run instead of the whole gallery.
+          for attempt in 1 2 3; do
+            if [ "$attempt" -eq 1 ]; then
               make -C doc clean
-              make -C doc html SPHINXERRWARN="-W"
+            else
+              echo "Retrying docs build (attempt ${attempt}) without full clean so only failed examples re-run..."
+              sleep 10
+            fi
+            if make -C doc html SPHINXERRWARN="-W" 2>&1 | tee build-html.log; then
+              break
+            fi
+            if grep -q 'grpc_details=ping timeout' build-html.log; then
+              if [ "$attempt" -eq 3 ]; then
+                echo "Docs build failed with gRPC ping timeout after ${attempt} attempts."
+                exit 1
+              fi
             else
               exit 1
             fi
-          fi
+          done
         env:
           PYSYC_DOC_BUILD_VERSION: ${{ env.DOC_BUILD_SYC_VERSION }}
           PYSYC_BUILD_SPHINX_GALLERY: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,9 @@ jobs:
         env:
           PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
 
-      - name: Unit Test v26.1.0
+      - name: Unit Test v26.1.0 (attempt 1)
+        id: unit_test_v261_attempt1
+        continue-on-error: true
         uses: ./.github/actions/unit-test
         with:
           image-tag: v26.1.0
@@ -281,6 +283,24 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
           PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
+
+      - name: Unit Test v26.1.0 (attempt 2 on transient failure)
+        id: unit_test_v261_attempt2
+        if: steps.unit_test_v261_attempt1.outcome == 'failure'
+        continue-on-error: true
+        uses: ./.github/actions/unit-test
+        with:
+          image-tag: v26.1.0
+          upload-coverage: true
+        env:
+          ANSYSLMD_LICENSE_FILE: "1055@${{ secrets.LICENSE_SERVER }}"
+          PYSYC_GRPC_CHANNEL_OPTIONS_JSON: ${{ env.PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261 }}
+
+      - name: Fail if v26.1 retries exhausted
+        if: steps.unit_test_v261_attempt1.outcome == 'failure' && steps.unit_test_v261_attempt2.outcome == 'failure'
+        run: |
+          echo "v26.1 unit tests failed on both attempts."
+          exit 1
 
       #- name: Unit Test latest
       #  uses: ./.github/actions/unit-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   PACKAGE_NAMESPACE: "ansys.systemcoupling.core"
   DOCUMENTATION_CNAME: "systemcoupling.docs.pyansys.com"
   DOC_BUILD_SYC_VERSION: 26_1
-  GRPCIO_VERSION_261: "1.73.1"
+  GRPCIO_VERSION_261: "1.81.1"
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"
@@ -239,12 +239,14 @@ jobs:
 
       - name: Pin grpcio for v26.1 tests
         run: |
-          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} > /dev/null
+          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} grpcio-health-checking==${GRPCIO_VERSION_261} > /dev/null
           python - <<'PY'
           import grpc
           import grpc_status
+          import grpc_health
           print(f"grpcio version: {grpc.__version__}")
           print(f"grpcio-status module: {grpc_status.__name__}")
+          print(f"grpcio-health-checking module: {grpc_health.__name__}")
           PY
         env:
           GRPCIO_VERSION_261: ${{ env.GRPCIO_VERSION_261 }}
@@ -297,12 +299,14 @@ jobs:
 
       - name: Pin grpcio for docs build (v26.1)
         run: |
-          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} > /dev/null
+          pip install -q --force-reinstall grpcio==${GRPCIO_VERSION_261} grpcio-status==${GRPCIO_VERSION_261} grpcio-health-checking==${GRPCIO_VERSION_261} > /dev/null
           python - <<'PY'
           import grpc
           import grpc_status
+          import grpc_health
           print(f"grpcio version: {grpc.__version__}")
           print(f"grpcio-status module: {grpc_status.__name__}")
+          print(f"grpcio-health-checking module: {grpc_health.__name__}")
           PY
         env:
           GRPCIO_VERSION_261: ${{ env.GRPCIO_VERSION_261 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,13 @@ env:
   # try to avoid ping timeout issues. This is mainly seen in the long-running
   # "solve" RPC. Review whether this remains necessary with future versions.
   GRPCIO_VERSION_261: "1.81.1"
-  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 30000, "grpc.keepalive_timeout_ms": 300000, "grpc.keepalive_permit_without_calls": 1, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 10000, "grpc.http2.min_ping_interval_without_data_ms": 10000}'
+  # gRPC channel options for v26.1: Passive keepalive strategy to prevent ping
+  # timeouts during long-running solve() RPC calls. Key philosophy:
+  # 1. Virtually disable client-initiated pinging (~24 days interval)
+  # 2. Only ping when waiting on an active RPC, not when idle
+  # 3. Use conservative 5-minute spacing to align with server defaults
+  # 4. Don't timeout waiting for ping responses
+  PYSYC_GRPC_CHANNEL_OPTIONS_JSON_261: '{"grpc.keepalive_time_ms": 2147483647, "grpc.keepalive_timeout_ms": 2147483647, "grpc.keepalive_permit_without_calls": 0, "grpc.http2.max_pings_without_data": 0, "grpc.http2.min_time_between_pings_ms": 300000, "grpc.http2.min_ping_interval_without_data_ms": 300000}'
   FLUENT_IMAGE_VERSION: "v25.2.0"
   SYC_IMAGE_VERSION: "v26.1.0"
   MAPDL_IMAGE_VERSION: "v25.2-ubuntu-cicd"

--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,8 @@ by examining the following environment variables in this order:
 * ``AWP_ROOT`` - this is assumed to point to a root Ansys folder, under which a
   ``SystemCoupling`` folder is present.
 * ``AWP_ROOT<NNN>`` - these are standard environment variables that are automatically
-  set by Ansys installations, where ``<NNN>`` is a version number, such as 252 for
-  Ansys 25 R2. As noted above, if multiple such variables are set, the one with the
+  set by Ansys installations, where ``<NNN>`` is a version number (such as 261 for
+  Ansys 26 R1). As noted above, if multiple such variables are set, the one with the
   highest recognized version number is used.
 
 If ``SYSC_ROOT`` or ``AWP_ROOT`` is set but does not refer to a valid installation, PySystemCoupling

--- a/doc/changelog.d/661.added.md
+++ b/doc/changelog.d/661.added.md
@@ -1,0 +1,1 @@
+Maint: Prepare for release targeting v261

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -272,7 +272,11 @@ sphinx_gallery_conf = {
     # "plot_gallery": False,
     # Suppress config comments like "sphinx_gallery_thumbnail_path" from being rendered
     "remove_config_comments": True,
-    "abort_on_example_error": True,
+    # Keep False so the full gallery attempts all examples even if one fails.
+    # This allows CI to retry only the failed examples on a subsequent run
+    # (sphinx-gallery skips examples whose .md5 file already matches).
+    # make clean is NOT run between retries so the .md5 files are preserved.
+    "abort_on_example_error": False,
 }
 
 # -- Options for warning control ---------------------------------------------

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -42,15 +42,15 @@ after the preceding steps for cloning and installing the package.
 The generated code is written to the directory ``src/ansys/systemcoupling/core/adaptor/api_<version>``,
 where ``<version>`` is the version of the System Coupling instance that was run in the background
 by the generation script. For example, the version ``25_2`` corresponds to System Coupling 2025 R2.
-The default is ``25_2``, which means that this release of System Coupling is expected to be at the
-installation location given by the ``AWP_ROOT252`` environment variable.
+The default is derived by looking for the highest recognized Ansys version with a valid System
+Coupling installation, based on environment variables of the form ``AWP_ROOT<NNN>``.
 
 You can override the default behavior and run a different version, and generate the API classes for
 this different version, by setting either the ``SYSC_ROOT`` environment variable to point to the
 root directory of your System Coupling installation or the ``AWP_ROOT`` environment variable to
 point to the root of an Ansys installation. If ``SYSC_ROOT`` and ``AWP_ROOT`` environment variables
 are both set, the former takes priority. Additionally, both of these environment variables take priority
-over the ``AWP_ROOT252`` environment variable.
+over the ``AWP_ROOT<NNN>`` environment variables.
 
 
 Build documentation

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -12,7 +12,7 @@ PySystemCoupling supports Ansys System Coupling version 2023 R1 and later.
 
    The detailed documentation, particularly that in the :ref:`ref_index_api`
    section, is based on the *current* official Ansys release at this release of
-   PySystemCoupling. This is **2025 R2**. Although the majority of it does not change
+   PySystemCoupling. This is **2026 R1**. Although the majority of it does not change
    between releases, you should consult the API documentation for an earlier
    applicable release of PySystemCoupling if you are running with an older System
    Coupling version and want to be sure of the details.
@@ -25,7 +25,7 @@ Install PySystemCoupling
 ========================
 
 The ``ansys-systemcoupling-core`` package currently supports Python 3.10 through
-Python 3.12 on Windows and Linux.
+Python 3.14 on Windows and Linux.
 
 Install the latest release from `PyPI <https://pypi.org/project/ansys-systemcoupling-core/>`_
 with this command:

--- a/examples/00-systemcoupling/cht_pipe.py
+++ b/examples/00-systemcoupling/cht_pipe.py
@@ -68,7 +68,7 @@ import ansys.fluent.core as pyfluent
 import ansys.mapdl.core as pymapdl
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import LOG, examples
+from ansys.systemcoupling.core import examples
 
 # %%
 # Download the Fluent mesh file.
@@ -206,7 +206,6 @@ fluent.solution.run_calculation.iter_count = 20
 # System Coupling setup involves adding the structural and fluid
 # participants, adding coupled interfaces and data transfers,
 # and setting other coupled analysis settings.
-LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True)
 # %%
 # Add participants by passing session handles to System Coupling.

--- a/examples/00-systemcoupling/cht_pipe.py
+++ b/examples/00-systemcoupling/cht_pipe.py
@@ -68,7 +68,7 @@ import ansys.fluent.core as pyfluent
 import ansys.mapdl.core as pymapdl
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import examples
+from ansys.systemcoupling.core import LOG, examples
 
 # %%
 # Download the Fluent mesh file.
@@ -171,30 +171,32 @@ mapdl.antype(0)
 # Set up the fluid analysis and read the pre-created mesh file
 # ------------------------------------------------------------
 
-fluent = pyfluent.launch_fluent(start_transcript=False, product_version=252)
-fluent.file.read(file_type="mesh", file_name=fluent_msh_file)
+fluent = pyfluent.launch_fluent(start_transcript=False)
+fluent.settings.file.read(file_type="mesh", file_name=fluent_msh_file)
 
 # %%
 # Define the fluid solver settings.
-fluent.setup.models.energy.enabled = True
+fluent.settings.setup.models.energy.enabled = True
 
 # %%
 # Add the material.
-fluent.setup.materials.database.copy_by_name(type="fluid", name="water-liquid")
+fluent.settings.setup.materials.database.copy_by_name(type="fluid", name="water-liquid")
 
-fluent.setup.cell_zone_conditions.fluid["fff_fluiddomain"].material = "water-liquid"
+fluent.settings.setup.cell_zone_conditions.fluid["fff_fluiddomain"].general.material = (
+    "water-liquid"
+)
 
 # %%
 # Define boundary conditions.
-fluent.setup.boundary_conditions.velocity_inlet["inlet"].momentum.velocity = (
-    0.1  # units: m/s
-)
-fluent.setup.boundary_conditions.velocity_inlet["inlet"].thermal.temperature = (
-    300  # Units: Kelvin
-)
-fluent.setup.boundary_conditions.wall["inner_wall"].thermal.thermal_bc = (
-    "via System Coupling"
-)
+fluent.settings.setup.boundary_conditions.velocity_inlet[
+    "inlet"
+].momentum.velocity_magnitude = 0.1  # units: m/s
+fluent.settings.setup.boundary_conditions.velocity_inlet[
+    "inlet"
+].thermal.temperature = 300  # Units: Kelvin
+fluent.settings.setup.boundary_conditions.wall[
+    "inner_wall"
+].thermal.thermal_condition = "via System Coupling"
 
 fluent.solution.run_calculation.iter_count = 20
 
@@ -204,8 +206,8 @@ fluent.solution.run_calculation.iter_count = 20
 # System Coupling setup involves adding the structural and fluid
 # participants, adding coupled interfaces and data transfers,
 # and setting other coupled analysis settings.
+LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True)
-
 # %%
 # Add participants by passing session handles to System Coupling.
 fluid_name = syc.setup.add_participant(participant_session=fluent)

--- a/examples/00-systemcoupling/fluid_swirl.py
+++ b/examples/00-systemcoupling/fluid_swirl.py
@@ -70,7 +70,7 @@ import math
 import ansys.fluent.core as pyfluent
 
 import ansys.systemcoupling.core as pysystemcoupling
-from ansys.systemcoupling.core import examples
+from ansys.systemcoupling.core import LOG, examples
 
 # %%
 #
@@ -97,6 +97,7 @@ fluent_cas_file = examples.download_file(
 #    use ``product_version`` argument to the ``launch_fluent``
 #    function, for example ``pyfluent.launch_fluent(product_version="24.2.0")``
 fluent = pyfluent.launch_fluent(start_transcript=True, processor_count=4)
+LOG.set_level("DEBUG")
 syc = pysystemcoupling.launch()
 
 # %%
@@ -111,7 +112,7 @@ syc = pysystemcoupling.launch()
 
 # %%
 # Read the pre-created case file.
-fluent.file.read(file_type="case", file_name=fluent_cas_file)
+fluent.settings.file.read(file_type="case", file_name=fluent_cas_file)
 
 # %%
 # Generate the SCDT file
@@ -206,21 +207,23 @@ syc.solution.solve()
 # Generate an image with fluid flow streamlines using PyFluent post-processing.
 # Note how the force values defined in the SCDT file induce the swirl in
 # the fluid flow.
-if fluent.results.graphics.picture.use_window_resolution.is_active():
-    fluent.results.graphics.picture.use_window_resolution = False
+if fluent.settings.results.graphics.picture.use_window_resolution.is_active():
+    fluent.settings.results.graphics.picture.use_window_resolution = False
 
-fluent.results.graphics.picture.x_resolution = 1920
-fluent.results.graphics.picture.y_resolution = 1440
+fluent.settings.results.graphics.picture.x_resolution = 1920
+fluent.settings.results.graphics.picture.y_resolution = 1440
 
-fluent.results.graphics.pathline["pathline"] = {}
-pathline = fluent.results.graphics.pathline["pathline"]
+fluent.settings.results.graphics.pathline["pathline"] = {}
+pathline = fluent.settings.results.graphics.pathline["pathline"]
 pathline.field = "velocity-magnitude"
 pathline.release_from_surfaces = ["in"]
 pathline.display()
 
-fluent.results.graphics.views.restore_view(view_name="isometric")
-fluent.results.graphics.views.auto_scale()
-fluent.results.graphics.picture.save_picture(file_name="fluid_swirl_pathline.png")
+fluent.settings.results.graphics.views.restore_view(view_name="isometric")
+fluent.settings.results.graphics.views.auto_scale()
+fluent.settings.results.graphics.picture.save_picture(
+    file_name="fluid_swirl_pathline.png"
+)
 
 ###############################################################################
 # .. image:: /_static/fluid_swirl_pathline.png

--- a/examples/00-systemcoupling/fluid_swirl.py
+++ b/examples/00-systemcoupling/fluid_swirl.py
@@ -70,7 +70,7 @@ import math
 import ansys.fluent.core as pyfluent
 
 import ansys.systemcoupling.core as pysystemcoupling
-from ansys.systemcoupling.core import LOG, examples
+from ansys.systemcoupling.core import examples
 
 # %%
 #
@@ -97,7 +97,6 @@ fluent_cas_file = examples.download_file(
 #    use ``product_version`` argument to the ``launch_fluent``
 #    function, for example ``pyfluent.launch_fluent(product_version="24.2.0")``
 fluent = pyfluent.launch_fluent(start_transcript=True, processor_count=4)
-LOG.set_level("DEBUG")
 syc = pysystemcoupling.launch()
 
 # %%

--- a/examples/00-systemcoupling/heating_tank_fmu_fmu.py
+++ b/examples/00-systemcoupling/heating_tank_fmu_fmu.py
@@ -83,7 +83,7 @@ One coupling interface between the FMUs with two data transfers :
 # sphinx_gallery_thumbnail_path = '_static/fmu_fmu.png'
 
 import ansys.systemcoupling.core as pysystemcoupling
-from ansys.systemcoupling.core import LOG, examples
+from ansys.systemcoupling.core import examples
 
 # %%
 #
@@ -107,7 +107,6 @@ fmu_file_tank = examples.download_file(
 # Launch a remote System Coupling instance and return a *client* object
 # (a ``Session`` object) that allows you to interact with System Coupling
 # via an API exposed into the current Python environment.
-LOG.set_level("DEBUG")
 syc = pysystemcoupling.launch(start_output=True)
 # %%
 # Set up the coupled analysis

--- a/examples/00-systemcoupling/heating_tank_fmu_fmu.py
+++ b/examples/00-systemcoupling/heating_tank_fmu_fmu.py
@@ -44,10 +44,11 @@ temperature of the fluid is available as an output, modelling a sensor
 in the tank. The FMU has six parameters that can be set:
 
     - Height and base radius of the cylindrical tank [m]
-    - Density [kg m\ :sup:`-3`\ ] and specific heat [W kg\ :sup:`-1`\ K\ :sup:`-1`\] of the fluid
+    - Density [kg m\\ :sup:`-3`\\ ] and specific heat
+      [W kg\\ :sup:`-1`\\ K\\ :sup:`-1`\\] of the fluid
       (by default, set to the properties of water)
     - Convection heat transfer coefficient between the fluid and its
-      surroundings [W m\ :sup:`-2`\ K\ :sup:`-1`\]
+      surroundings [W m\\ :sup:`-2`\\ K\\ :sup:`-1`\\]
     - Temperature of the tank's surroundings [K].
 
 The thermostat receives a temperature from the tank sensor and outputs
@@ -57,8 +58,8 @@ to determine the heat output and has five parameters that can be set:
     - Target temperature [K]
     - Maximum heat output [W]
     - Heat scale proportional factor [W/K]
-    - Heat scale integral factor [W K\ :sup:`-1`\ s\ :sup:`-1`\]
-    - Heat scale derivative factor [W s K\ :sup:`-1`\]
+    - Heat scale integral factor [W K\\ :sup:`-1`\\ s\\ :sup:`-1`\\]
+    - Heat scale derivative factor [W s K\\ :sup:`-1`\\]
 
 One coupling interface between the FMUs with two data transfers :
 
@@ -82,7 +83,7 @@ One coupling interface between the FMUs with two data transfers :
 # sphinx_gallery_thumbnail_path = '_static/fmu_fmu.png'
 
 import ansys.systemcoupling.core as pysystemcoupling
-from ansys.systemcoupling.core import examples
+from ansys.systemcoupling.core import LOG, examples
 
 # %%
 #
@@ -106,8 +107,8 @@ fmu_file_tank = examples.download_file(
 # Launch a remote System Coupling instance and return a *client* object
 # (a ``Session`` object) that allows you to interact with System Coupling
 # via an API exposed into the current Python environment.
+LOG.set_level("DEBUG")
 syc = pysystemcoupling.launch(start_output=True)
-
 # %%
 # Set up the coupled analysis
 # ---------------------------

--- a/examples/00-systemcoupling/oscillating_plate.py
+++ b/examples/00-systemcoupling/oscillating_plate.py
@@ -71,7 +71,7 @@ import ansys.fluent.core as pyfluent
 import ansys.mapdl.core as pymapdl
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import examples
+from ansys.systemcoupling.core import LOG, examples
 
 # %%
 #
@@ -92,8 +92,8 @@ fluent_cas_file = examples.download_file(
 # these products via APIs exposed into the current Python environment.
 mapdl = pymapdl.launch_mapdl()
 fluent = pyfluent.launch_fluent(start_transcript=False)
+LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True)
-
 # %%
 # Setup
 # -----
@@ -158,7 +158,7 @@ mapdl.timint("on")
 
 # %%
 # Read the pre-created case file
-fluent.file.read(file_type="case", file_name=fluent_cas_file)
+fluent.settings.file.read(file_type="case", file_name=fluent_cas_file)
 
 
 # %%
@@ -223,14 +223,14 @@ print(f"There are {len(node_ids)} nodes. Maximum x-displacement is {max_dx}")
 # Post-process the fluids results
 
 # use_window_resolution option not active inside containers or Ansys Lab environment
-if fluent.results.graphics.picture.use_window_resolution.is_active():
-    fluent.results.graphics.picture.use_window_resolution = False
+if fluent.settings.results.graphics.picture.use_window_resolution.is_active():
+    fluent.settings.results.graphics.picture.use_window_resolution = False
 
-fluent.results.graphics.picture.x_resolution = 1920
-fluent.results.graphics.picture.y_resolution = 1440
+fluent.settings.results.graphics.picture.x_resolution = 1920
+fluent.settings.results.graphics.picture.y_resolution = 1440
 
-fluent.results.graphics.contour["contour_static_pressure"] = {}
-contour = fluent.results.graphics.contour["contour_static_pressure"]
+fluent.settings.results.graphics.contour["contour_static_pressure"] = {}
+contour = fluent.settings.results.graphics.contour["contour_static_pressure"]
 
 contour.colorings.banded = True
 contour.field = "pressure"
@@ -239,9 +239,11 @@ contour.filled = True
 contour.surfaces_list = ["symmetry1", "wall_deforming"]
 contour.display()
 
-fluent.results.graphics.views.restore_view(view_name="front")
-fluent.results.graphics.views.auto_scale()
-fluent.results.graphics.picture.save_picture(file_name="oscplate_pressure_contour.png")
+fluent.settings.results.graphics.views.restore_view(view_name="front")
+fluent.settings.results.graphics.views.auto_scale()
+fluent.settings.results.graphics.picture.save_picture(
+    file_name="oscplate_pressure_contour.png"
+)
 
 ###############################################################################
 # .. image:: /_static/oscplate_pressure_contour.png

--- a/examples/00-systemcoupling/oscillating_plate.py
+++ b/examples/00-systemcoupling/oscillating_plate.py
@@ -71,7 +71,7 @@ import ansys.fluent.core as pyfluent
 import ansys.mapdl.core as pymapdl
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import LOG, examples
+from ansys.systemcoupling.core import examples
 
 # %%
 #
@@ -92,7 +92,6 @@ fluent_cas_file = examples.download_file(
 # these products via APIs exposed into the current Python environment.
 mapdl = pymapdl.launch_mapdl()
 fluent = pyfluent.launch_fluent(start_transcript=False)
-LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True)
 # %%
 # Setup

--- a/examples/00-systemcoupling/turek_hron_fsi2.py
+++ b/examples/00-systemcoupling/turek_hron_fsi2.py
@@ -45,7 +45,7 @@ resides within a fluid filled channel:
    :align: center
 
 The flow is laminar with a Reynolds number of :math:`Re = 100`. The inlet velocity
-has a parabolic profile with a maximum value of :math:`1.5 \cdot \\bar{U}`, where :math:`\\bar{U}`
+has a parabolic profile with a maximum value of :math:`1.5 \\cdot \\bar{U}`, where :math:`\\bar{U}`
 is the average inlet velocity. The cylinder sits at an offset of :math:`0.05~m` to the
 incoming flow, causing an imbalance of surface forces on the elastic beam.
 The beam and the surrounding fluid are simulated for a few time steps to
@@ -73,7 +73,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import examples
+from ansys.systemcoupling.core import LOG, examples
 
 # %%
 #
@@ -108,6 +108,7 @@ lift_data_file = examples.download_file(
 
 mapdl = pymapdl.launch_mapdl()
 fluent = pyfluent.launch_fluent(processor_count=8)
+LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True, nprocs=10, sycnprocs=2)
 
 # %%
@@ -182,48 +183,50 @@ mapdl.outres("all", "all")
 
 # %%
 # Read the pre-created mesh file
-fluent.file.read(file_type="mesh", file_name=fluent_msh_file)
+fluent.settings.file.read(file_type="mesh", file_name=fluent_msh_file)
 fluent.mesh.check()
 
 # %%
 # Define fluids general solver settings
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-fluent.setup.general.solver.type = "pressure-based"
+fluent.settings.setup.general.solver.type = "pressure-based"
 fluent.solution.methods.high_order_term_relaxation.enable = True
 
 # %%
 # Define the fluid and update the material properties
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-fluent.setup.models.viscous.model = "laminar"
-fluent.setup.materials.fluid["fsi_fluid"] = {
+fluent.settings.setup.models.viscous.model = "laminar"
+fluent.settings.setup.materials.fluid["fsi_fluid"] = {
     "density": {"option": "constant", "value": FLUID_DENS},
     "viscosity": {"option": "constant", "value": viscosity},
 }
 
-fluent.setup.cell_zone_conditions.fluid["*fluid*"].general.material = "fsi_fluid"
-fluent.setup.materials.print_state()
+fluent.settings.setup.cell_zone_conditions.fluid["*fluid*"].general.material = (
+    "fsi_fluid"
+)
+fluent.settings.setup.materials.print_state()
 
 # %%
 # Create the parabolic inlet profile as a named expression
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-fluent.setup.named_expressions["u_bar"] = {  # average velocity
+fluent.settings.setup.named_expressions["u_bar"] = {  # average velocity
     "definition": f"{U_BAR} [m/s]"
 }
-fluent.setup.named_expressions["t_bar"] = {"definition": "1.0 [s]"}
-fluent.setup.named_expressions["y_bar"] = {"definition": "1.0 [m]"}
+fluent.settings.setup.named_expressions["t_bar"] = {"definition": "1.0 [s]"}
+fluent.settings.setup.named_expressions["y_bar"] = {"definition": "1.0 [m]"}
 
-fluent.setup.named_expressions["u_y"] = {
+fluent.settings.setup.named_expressions["u_y"] = {
     "definition": "1.5*u_bar*(4*(y/y_bar)*(0.41 - y/y_bar)/(0.41^2))"
 }
 
 # %%
 # Update the inlet field
 # ~~~~~~~~~~~~~~~~~~~~~~
-inlet_fluid = fluent.setup.boundary_conditions.velocity_inlet["inlet"]
+inlet_fluid = fluent.settings.setup.boundary_conditions.velocity_inlet["inlet"]
 inlet_fluid.momentum.initial_gauge_pressure.value = 0
-inlet_fluid.momentum.velocity.value = "u_y"
-fluent.setup.named_expressions.print_state()
+inlet_fluid.momentum.velocity_magnitude.value = "u_y"
+fluent.settings.setup.named_expressions.print_state()
 
 # %%
 # Setup any relevant solution controls
@@ -244,7 +247,7 @@ fluent.solution.run_calculation.iterate(iter_count=500)
 # %%
 # Switch to transient mode and prepare for coupling
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-fluent.setup.general.solver.time = "unsteady-2nd-order"
+fluent.settings.setup.general.solver.time = "unsteady-2nd-order"
 
 # %%
 # Define dynamic meshing
@@ -304,11 +307,11 @@ for zone in ["cylinder", "outlet", "inlet", "channel"]:
 # system coupling.
 fluent.solution.run_calculation.transient_controls.max_iter_per_time_step = 50
 
-fluent.file.auto_save.save_data_file_every.frequency_type = "time-step"
-fluent.file.auto_save.data_frequency = 20
-fluent.file.auto_save.root_name = "turek_hron_fluid_resolved"
-fluent.setup.materials.print_state()
-fluent.setup.cell_zone_conditions.print_state()
+fluent.settings.file.auto_save.save_data_file_every.frequency_type = "time-step"
+fluent.settings.file.auto_save.data_frequency = 20
+fluent.settings.file.auto_save.root_name = "turek_hron_fluid_resolved"
+fluent.settings.setup.materials.print_state()
+fluent.settings.setup.cell_zone_conditions.print_state()
 
 # %%
 # Set up the coupled analysis
@@ -444,14 +447,14 @@ plt.close()  # close the plot to avoid showing it in the docs.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # use_window_resolution option not active inside containers or Ansys Lab environment
 
-if fluent.results.graphics.picture.use_window_resolution.is_active():
-    fluent.results.graphics.picture.use_window_resolution = False
+if fluent.settings.results.graphics.picture.use_window_resolution.is_active():
+    fluent.settings.results.graphics.picture.use_window_resolution = False
 
-fluent.results.graphics.picture.x_resolution = 1920
-fluent.results.graphics.picture.y_resolution = 1440
+fluent.settings.results.graphics.picture.x_resolution = 1920
+fluent.settings.results.graphics.picture.y_resolution = 1440
 
-fluent.results.graphics.contour["contour_static_pressure"] = {}
-contour = fluent.results.graphics.contour["contour_static_pressure"]
+fluent.settings.results.graphics.contour["contour_static_pressure"] = {}
+contour = fluent.settings.results.graphics.contour["contour_static_pressure"]
 
 contour.colorings.banded = True
 contour.field = "pressure"
@@ -460,9 +463,9 @@ contour.filled = True
 contour.surfaces_list = ["back"]
 contour.display()
 
-fluent.results.graphics.views.restore_view(view_name="front")
-fluent.results.graphics.views.auto_scale()
-fluent.results.graphics.picture.save_picture(
+fluent.settings.results.graphics.views.restore_view(view_name="front")
+fluent.settings.results.graphics.views.auto_scale()
+fluent.settings.results.graphics.picture.save_picture(
     file_name="turek_horn_fsi2_pressure_contour.png"
 )
 

--- a/examples/00-systemcoupling/turek_hron_fsi2.py
+++ b/examples/00-systemcoupling/turek_hron_fsi2.py
@@ -73,7 +73,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import ansys.systemcoupling.core as pysyc
-from ansys.systemcoupling.core import LOG, examples
+from ansys.systemcoupling.core import examples
 
 # %%
 #
@@ -108,7 +108,6 @@ lift_data_file = examples.download_file(
 
 mapdl = pymapdl.launch_mapdl()
 fluent = pyfluent.launch_fluent(processor_count=8)
-LOG.set_level("DEBUG")
 syc = pysyc.launch(start_output=True, nprocs=10, sycnprocs=2)
 
 # %%

--- a/src/ansys/systemcoupling/core/__init__.py
+++ b/src/ansys/systemcoupling/core/__init__.py
@@ -76,15 +76,15 @@ def launch(
         ``None``, in which case the System Coupling server uses its own default.
     version : str or int, optional
         String or integer specifying the version of System Coupling to use. For example,
-        to use System Coupling from the Ansys "2024 R1" release, specify ``"241"`` or ``241``.
-        (The forms ``"24.1"`` and ``"24_1"`` are also acceptable.)
+        to use System Coupling from the Ansys "2025 R2" release, specify ``"252"`` or ``252``.
+        (The forms ``"25.2"`` and ``"25_2"`` are also acceptable.)
         The version will be sought in the standard installation location. The
-        default is ``None``, which is equivalent to specifying
-        ``"252"`` ("2025 R2" release), unless either of the environment
-        variables ``SYSC_ROOT`` or ``AWP_ROOT`` has been set. In that case,
-        the environment variable will be used to locate System Coupling.
-        If ``version`` is also provided, it will not be used to locate System
-        Coupling but it might still be used to infer some information about it.
+        default is ``None``, which is equivalent to using the latest installed
+        version, unless either of the environment variables ``SYSC_ROOT`` or ``AWP_ROOT``
+        has been set. In that case, the environment variable will be used to locate
+        System Coupling. If ``version`` is also provided in this case, it will not be
+        used to locate System Coupling but it might still be used to infer some information
+        about it.
     start_output: bool, optional
         Boolean to specify if the user wants to stream system coupling output.
         The default is ``False``, in which case the output stream is kept hidden.

--- a/src/ansys/systemcoupling/core/adaptor/impl/static_info.py
+++ b/src/ansys/systemcoupling/core/adaptor/impl/static_info.py
@@ -320,28 +320,6 @@ def get_extended_cmd_metadata(api, mode: SystemCouplingMode) -> list:
         the details of a command to be exposed.
     """
 
-    def fix_up_doc(cmd_metadata):
-        version = get_syc_version(api)
-        if version not in ("24.2", "25.1"):
-            return cmd_metadata
-
-        command_to_fix = None
-        if version == "24.2":
-            command_to_fix = "add_participant"
-        elif version == "25.1":
-            command_to_fix = "update_participant"
-
-        # There are bugs in doc text queried from 24.2 and 25.1 SyC.
-        # The "*" need to be escaped to avoid issues in Sphinx. This
-        # can be a surgical fix because these versions are frozen now.
-        for cmd in cmd_metadata:
-            if cmd["pyname"] == command_to_fix:
-                add_part_cmd = cmd
-                for arg_name, arg_info in add_part_cmd["args"]:
-                    if arg_name == "InputFile":
-                        arg_info["doc"] = arg_info["doc"].replace("*", r"\*")
-        return cmd_metadata
-
     def find_item_by_name(items: List[Dict], name: str) -> dict:
         for item in items:
             if item["name"] == name:
@@ -435,7 +413,7 @@ def get_extended_cmd_metadata(api, mode: SystemCouplingMode) -> list:
 
     injected_data = get_injected_cmd_metadata(mode)
     merge_data(cmd_metadata, injected_data)
-    cmd_metadata = fix_up_doc(cmd_metadata)
+    cmd_metadata = _fix_up_doc(api, cmd_metadata)
     return cmd_metadata
 
 
@@ -451,3 +429,95 @@ def make_named_object_level_map(dm_metadata, root_type) -> dict[int, str]:
     visit_children(dm_metadata[root_type], 0)
 
     return level_map
+
+
+def _fix_up_doc(api, cmd_metadata):
+    """This fixes up any doc issues that are now frozen into released
+    server version and therefore cannot be fixed in the server.
+
+    The fixes can be relatively ad hoc and specific because we know what the
+    issues are and that they won't be changing.
+
+    """
+
+    version = get_syc_version(api)
+
+    def fix_242_251():
+        command_to_fix = None
+        if version == "24.2":
+            command_to_fix = "add_participant"
+        elif version == "25.1":
+            command_to_fix = "update_participant"
+
+        # Replaced unescaped asterisk with escaped asterisk to fix
+        # rendering issue in the doc generated from the generated
+        # API code. A bare asterisk is treated as an emphasis markdown
+        # in reStructuredText.
+        # We used to add a simple single backslash but this creates
+        # syntax warnings in newer version of Python so we need to
+        # double up the backslash.
+        for cmd in cmd_metadata:
+            if cmd["pyname"] == command_to_fix:
+                add_part_cmd = cmd
+                for arg_name, arg_info in add_part_cmd["args"]:
+                    if arg_name == "InputFile":
+                        arg_info["doc"] = arg_info["doc"].replace("*", r"\\*")
+
+    def fix_261():
+        # Fixes are needed in:
+        #
+        # - "get_machines" : need to indent the 'code block' in the docstring and
+        #                    double up the colon in the preceding line.
+        # - "add_interface" : fix the escaped quote in docstring for the
+        #                    side_two_participant argument.
+        # - "add_participant" : fix the escaped asterisk.
+        for cmd in cmd_metadata:
+            if cmd["pyname"] == "get_machines":
+                # The docstring for this command includes a code block-like
+                # section that does not render correctly and generates warnings
+                # that cause the build to fail. Need to indent the section and
+                # double up the colon at the end of the preceding line.
+
+                doc: str = cmd["doc"]
+                doc = doc.replace(
+                    "Returns information in the following format:",
+                    "Returns information in the following format::",
+                )
+
+                # Fix indentation
+                lines = doc.splitlines()
+                indenting = False
+                for iline, line in enumerate(lines):
+                    if not indenting and line.lstrip().startswith("["):
+                        indenting = True
+                    if indenting:
+                        lines[iline] = "    " + line
+                    if indenting and line.lstrip().startswith("]"):
+                        break
+                doc = "\n".join(lines)
+
+                cmd["doc"] = doc
+            elif cmd["pyname"] == "add_interface":
+                # The quotes in "Two" are meant to be escaped, but the second
+                # backslash is actually after the second quote.
+                for arg_name, arg_info in cmd["args"]:
+                    if arg_name == "SideTwoParticipant":
+                        arg_info["doc"] = arg_info["doc"].replace(
+                            '\\"Two"\\', r"\"Two\""
+                        )
+            elif cmd["pyname"] in ("add_participant", "update_participant"):
+                # The docstring for the "InputFile" argument of these commands
+                # includes an asterisk that is escaped. This is now generating
+                # a syntax warning in Python when the string is written to the
+                # generated API Python file. However, the escape is needed for
+                # Sphinx. Fix by doubling it.
+                for arg_name, arg_info in cmd["args"]:
+                    if arg_name == "InputFile":
+                        arg_info["doc"] = arg_info["doc"].replace(r"\*", r"\\*")
+
+    if version in ("24.2", "25.1"):
+        fix_242_251()
+    elif version == "26.1":
+        fix_261()
+
+    return cmd_metadata

--- a/src/ansys/systemcoupling/core/client/grpc_transport.py
+++ b/src/ansys/systemcoupling/core/client/grpc_transport.py
@@ -22,6 +22,7 @@
 
 from dataclasses import dataclass, fields
 from enum import Enum
+import json
 import os
 import pathlib
 import re
@@ -45,6 +46,20 @@ from ansys.systemcoupling.core.util.logging import LOG
 _IS_WINDOWS = os.name == "nt"
 
 _version_re = re.compile(r"\bv[0-9][0-9][0-9]\b")
+
+_GRPC_CHANNEL_OPTIONS_JSON_ENV = "PYSYC_GRPC_CHANNEL_OPTIONS_JSON"
+_GRPC_CHANNEL_OPTIONS_INT_ENV = {
+    "PYSYC_GRPC_KEEPALIVE_TIME_MS": "grpc.keepalive_time_ms",
+    "PYSYC_GRPC_KEEPALIVE_TIMEOUT_MS": "grpc.keepalive_timeout_ms",
+    "PYSYC_GRPC_HTTP2_MAX_PINGS_WITHOUT_DATA": "grpc.http2.max_pings_without_data",
+    "PYSYC_GRPC_HTTP2_MIN_TIME_BETWEEN_PINGS_MS": "grpc.http2.min_time_between_pings_ms",
+    "PYSYC_GRPC_HTTP2_MIN_PING_INTERVAL_WITHOUT_DATA_MS": (
+        "grpc.http2.min_ping_interval_without_data_ms",
+    ),
+}
+_GRPC_CHANNEL_OPTIONS_BOOL_ENV = {
+    "PYSYC_GRPC_KEEPALIVE_PERMIT_WITHOUT_CALLS": "grpc.keepalive_permit_without_calls",
+}
 
 
 class ConnectionType(Enum):
@@ -232,6 +247,9 @@ class StartupAndConnectionInfo:
             )
 
         LOG.info(f"Creating gRPC channel with transport mode: {opt.transport_mode}")
+        grpc_options = _grpc_channel_options_from_env()
+        if grpc_options:
+            LOG.info(f"Applying gRPC channel options from environment: {grpc_options}")
         return create_channel(
             opt.transport_mode.value,
             host=opt.host,
@@ -240,6 +258,7 @@ class StartupAndConnectionInfo:
             uds_dir=opt.uds_dir,
             uds_id=opt.uds_id,
             certs_dir=opt.certs_folder,
+            grpc_options=grpc_options,
         )
 
     def _make_options(
@@ -340,6 +359,63 @@ class StartupAndConnectionInfo:
         if self._options.port is None:
             self._options.port = _find_port()
         return self._options.port
+
+
+def _grpc_channel_options_from_env() -> list[tuple[str, object]] | None:
+    options: dict[str, object] = {}
+
+    raw_options = os.environ.get(_GRPC_CHANNEL_OPTIONS_JSON_ENV)
+    if raw_options:
+        try:
+            parsed = json.loads(raw_options)
+            if isinstance(parsed, dict):
+                for key, value in parsed.items():
+                    options[str(key)] = value
+            elif isinstance(parsed, list):
+                for item in parsed:
+                    if (
+                        isinstance(item, (list, tuple))
+                        and len(item) == 2
+                        and isinstance(item[0], str)
+                    ):
+                        options[item[0]] = item[1]
+                    else:
+                        raise ValueError(
+                            "Items must be [name, value] pairs when JSON is a list."
+                        )
+            else:
+                raise ValueError(
+                    "JSON content must be an object or list of [name, value] pairs."
+                )
+        except Exception as exc:
+            LOG.warning(
+                f"Ignoring invalid {_GRPC_CHANNEL_OPTIONS_JSON_ENV} value: {exc}"
+            )
+
+    for env_var, grpc_key in _GRPC_CHANNEL_OPTIONS_INT_ENV.items():
+        value = os.environ.get(env_var)
+        if value is None:
+            continue
+        try:
+            options[grpc_key] = int(value)
+        except ValueError:
+            LOG.warning(f"Ignoring invalid integer value for {env_var}: '{value}'")
+
+    for env_var, grpc_key in _GRPC_CHANNEL_OPTIONS_BOOL_ENV.items():
+        value = os.environ.get(env_var)
+        if value is None:
+            continue
+        lowered = value.strip().lower()
+        if lowered in ("1", "true", "yes", "on"):
+            options[grpc_key] = 1
+        elif lowered in ("0", "false", "no", "off"):
+            options[grpc_key] = 0
+        else:
+            LOG.warning(f"Ignoring invalid boolean value for {env_var}: '{value}'")
+
+    if not options:
+        return None
+    return list(options.items())
 
 
 def _grpc_argument_category(version: tuple[int, int]) -> StartupArgumentCategory:

--- a/src/ansys/systemcoupling/core/client/services/command_query.py
+++ b/src/ansys/systemcoupling/core/client/services/command_query.py
@@ -35,5 +35,7 @@ class CommandQueryService:
             response, call = self.__stub.InvokeCommand.with_call(request)
             return response, call.trailing_metadata()
         except grpc.RpcError as rpc_error:
-            msg = handle_rpc_error(rpc_error)
+            msg = handle_rpc_error(
+                rpc_error, operation=f"InvokeCommand({request.command})"
+            )
             raise RuntimeError(msg) from None

--- a/src/ansys/systemcoupling/core/client/services/handle_rpc_error.py
+++ b/src/ansys/systemcoupling/core/client/services/handle_rpc_error.py
@@ -49,26 +49,30 @@ def _check_for_syc_exception(rpc_error):
 def _rpc_context_msg(rpc_error: grpc.RpcError) -> str:
     parts = []
 
+    # Bandit errors suppressed here. If we can't extract an element
+    # of the RPC error, we just skip it. We don't want to raise an exception while
+    # trying to report an exception.
+
     try:
         code = rpc_error.code()
         if code is not None:
             parts.append(f"grpc_code={code}")
     except Exception:
-        pass
+        pass  # nosec B110
 
     try:
         details = rpc_error.details()
         if details:
             parts.append(f"grpc_details={details}")
     except Exception:
-        pass
+        pass  # nosec B110
 
     try:
         debug = rpc_error.debug_error_string()
         if debug:
             parts.append(f"grpc_debug={debug}")
     except Exception:
-        pass
+        pass  # nosec B110
 
     return "\n".join(parts)
 

--- a/src/ansys/systemcoupling/core/client/services/handle_rpc_error.py
+++ b/src/ansys/systemcoupling/core/client/services/handle_rpc_error.py
@@ -46,19 +46,60 @@ def _check_for_syc_exception(rpc_error):
     return None
 
 
-def handle_rpc_error(rpc_error: grpc.RpcError):
+def _rpc_context_msg(rpc_error: grpc.RpcError) -> str:
+    parts = []
+
+    try:
+        code = rpc_error.code()
+        if code is not None:
+            parts.append(f"grpc_code={code}")
+    except Exception:
+        pass
+
+    try:
+        details = rpc_error.details()
+        if details:
+            parts.append(f"grpc_details={details}")
+    except Exception:
+        pass
+
+    try:
+        debug = rpc_error.debug_error_string()
+        if debug:
+            parts.append(f"grpc_debug={debug}")
+    except Exception:
+        pass
+
+    return "\n".join(parts)
+
+
+def handle_rpc_error(rpc_error: grpc.RpcError, operation: str | None = None):
     msg = _check_for_syc_exception(rpc_error)
     if msg is not None:
+        if operation:
+            msg = f"{operation} failed. {msg}"
         return msg
 
     status = from_call(rpc_error)
     if status is None:
-        return "Command or query execution failed. No details available."
+        msg = "Command or query execution failed. No details available."
+        if operation:
+            msg = f"{operation} failed. {msg}"
+        context = _rpc_context_msg(rpc_error)
+        if context:
+            msg += f"\n\nRPC transport context:\n{context}"
+        return msg
 
     msg = f"Command execution failed: {status.message} (code={status.code})"
+    if operation:
+        msg = f"{operation} failed. {msg}"
     for detail in status.details:
         if detail.Is(syc_error_pb2.ErrorDetails.DESCRIPTOR):
             error_details = syc_error_pb2.ErrorDetails()
             detail.Unpack(error_details)
             msg += _error_details_msg(error_details)
+
+    context = _rpc_context_msg(rpc_error)
+    if context:
+        msg += f"\n\nRPC transport context:\n{context}"
     return msg

--- a/src/ansys/systemcoupling/core/client/services/solution.py
+++ b/src/ansys/systemcoupling/core/client/services/solution.py
@@ -36,7 +36,7 @@ class SolutionService:
         try:
             self.__stub.Solve(request)
         except grpc.RpcError as rpc_error:
-            msg = handle_rpc_error(rpc_error)
+            msg = handle_rpc_error(rpc_error, operation="Solution.Solve")
             raise RuntimeError(msg) from None
 
     def interrupt(self, reason):

--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -186,9 +186,12 @@ def start_container(
         run_args.insert(idx, "-e")
 
     if network:
-        idx = run_args.index("-p")
-        run_args.insert(idx, network)
-        run_args.insert(idx, "--network")
+        if "--network=host" in run_args:
+            LOG.warning("Ignoring 'network' argument because --network=host is active.")
+        else:
+            idx = run_args.index("-p")
+            run_args.insert(idx, network)
+            run_args.insert(idx, "--network")
 
     LOG.debug(f"Running container with command: {' '.join(run_args)}")
 

--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -87,25 +87,11 @@ def start_container(
     is_github_action = os.getenv("GITHUB_ACTIONS") == "true"
     if not is_latest:
         major, minor, sp_suffix = _major_minor_sp_from_version(image_tag)
-        use_new_transport_args = sp_suffix or (major, minor) > (25, 2)
+        use_new_transport_args = bool(sp_suffix) or (major, minor) > (25, 2)
         bypass_docker_bridge_routing = is_github_action and (major, minor) >= (25, 2)
     else:
         use_new_transport_args = True
         bypass_docker_bridge_routing = is_github_action
-
-    keepalive_server_settings = []
-    if bypass_docker_bridge_routing:
-        keepalive_server_settings = [
-            "-e",
-            # Server pings client only once every 2 hours
-            "GRPC_ARG_KEEPALIVE_TIME_MS=7200000",
-            "-e",
-            # Disables the 2-strike disconnect rule
-            "GRPC_ARG_HTTP2_MAX_PING_STRIKES=0",
-            "-e",
-            # Accepts client packets without limit
-            "GRPC_ARG_HTTP2_MIN_PING_INTERVAL_WITHOUT_DATA_MS=0",
-        ]
 
     if use_new_transport_args:
         args = [
@@ -125,29 +111,23 @@ def start_container(
 
     mounted_from = str(Path(mounted_from).absolute())
 
-    run_args = (
-        [
-            "docker",
-            "run",
-            "-d",
-            "--rm",
-            "-p",
-            f"{port}:{port}",
-            "-v",
-            f"{mounted_from}:{mounted_to}",
-            "-w",
-            mounted_to,
-            "-e",
-            f"{_MPI_VERSION_VAR}={_MPI_VERSION}",
-            "-e",
-            f"AWP_ROOT=/ansys_inc",
-        ]
-        + keepalive_server_settings
-        + [
-            f"ghcr.io/ansys/pysystem-coupling:{image_tag}",
-        ]
-        + args
-    )
+    run_args = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "-p",
+        f"{port}:{port}",
+        "-v",
+        f"{mounted_from}:{mounted_to}",
+        "-w",
+        mounted_to,
+        "-e",
+        f"{_MPI_VERSION_VAR}={_MPI_VERSION}",
+        "-e",
+        f"AWP_ROOT=/ansys_inc",
+        f"ghcr.io/ansys/pysystem-coupling:{image_tag}",
+    ] + args
 
     # Additional environment
     container_user = os.getenv("SYC_CONTAINER_USER")

--- a/src/ansys/systemcoupling/core/client/syc_container.py
+++ b/src/ansys/systemcoupling/core/client/syc_container.py
@@ -83,9 +83,29 @@ def start_container(
 
     # Now use the image tag as definitive source of version info to
     # decide on transport args.
-    if not (use_new_transport_args := image_tag == "latest"):
+    is_latest = image_tag == "latest"
+    is_github_action = os.getenv("GITHUB_ACTIONS") == "true"
+    if not is_latest:
         major, minor, sp_suffix = _major_minor_sp_from_version(image_tag)
         use_new_transport_args = sp_suffix or (major, minor) > (25, 2)
+        bypass_docker_bridge_routing = is_github_action and (major, minor) >= (25, 2)
+    else:
+        use_new_transport_args = True
+        bypass_docker_bridge_routing = is_github_action
+
+    keepalive_server_settings = []
+    if bypass_docker_bridge_routing:
+        keepalive_server_settings = [
+            "-e",
+            # Server pings client only once every 2 hours
+            "GRPC_ARG_KEEPALIVE_TIME_MS=7200000",
+            "-e",
+            # Disables the 2-strike disconnect rule
+            "GRPC_ARG_HTTP2_MAX_PING_STRIKES=0",
+            "-e",
+            # Accepts client packets without limit
+            "GRPC_ARG_HTTP2_MIN_PING_INTERVAL_WITHOUT_DATA_MS=0",
+        ]
 
     if use_new_transport_args:
         args = [
@@ -105,23 +125,29 @@ def start_container(
 
     mounted_from = str(Path(mounted_from).absolute())
 
-    run_args = [
-        "docker",
-        "run",
-        "-d",
-        "--rm",
-        "-p",
-        f"{port}:{port}",
-        "-v",
-        f"{mounted_from}:{mounted_to}",
-        "-w",
-        mounted_to,
-        "-e",
-        f"{_MPI_VERSION_VAR}={_MPI_VERSION}",
-        "-e",
-        f"AWP_ROOT=/ansys_inc",
-        f"ghcr.io/ansys/pysystem-coupling:{image_tag}",
-    ] + args
+    run_args = (
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            f"{port}:{port}",
+            "-v",
+            f"{mounted_from}:{mounted_to}",
+            "-w",
+            mounted_to,
+            "-e",
+            f"{_MPI_VERSION_VAR}={_MPI_VERSION}",
+            "-e",
+            f"AWP_ROOT=/ansys_inc",
+        ]
+        + keepalive_server_settings
+        + [
+            f"ghcr.io/ansys/pysystem-coupling:{image_tag}",
+        ]
+        + args
+    )
 
     # Additional environment
     container_user = os.getenv("SYC_CONTAINER_USER")
@@ -132,6 +158,13 @@ def start_container(
         # Licensing can't log to default location if user is not the default 'root'
         run_args.insert(idx, f"ANSYSLC_APPLOGDIR={mounted_to}")
         run_args.insert(idx, "-e")
+
+    if bypass_docker_bridge_routing:
+        # replace -p <port>:<port> with --network=host to bypass Docker's network
+        # address translation
+        idx = run_args.index("-p")
+        del run_args[idx : idx + 2]
+        run_args.insert(idx, "--network=host")
 
     license_server = os.getenv("ANSYSLMD_LICENSE_FILE")
     if license_server:
@@ -156,6 +189,8 @@ def start_container(
         idx = run_args.index("-p")
         run_args.insert(idx, network)
         run_args.insert(idx, "--network")
+
+    LOG.debug(f"Running container with command: {' '.join(run_args)}")
 
     # Exclude Bandit check. No untrusted input to arguments.
     subprocess.run(run_args)  # nosec B603

--- a/src/ansys/systemcoupling/core/syc_version.py
+++ b/src/ansys/systemcoupling/core/syc_version.py
@@ -25,8 +25,8 @@ from typing import Tuple
 
 # Define constants relating to the default/current version of System Coupling
 
-SYC_MAJOR_VERSION = 25
-SYC_MINOR_VERSION = 2
+SYC_MAJOR_VERSION = 26
+SYC_MINOR_VERSION = 1
 
 SYC_VERSION_CONCAT = f"{SYC_MAJOR_VERSION}{SYC_MINOR_VERSION}"
 SYC_VERSION_DOT = f"{SYC_MAJOR_VERSION}.{SYC_MINOR_VERSION}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,4 +37,4 @@ def image_tag_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # Expect env var to be set to different values in GH pipelines
     # but this provides a convenient place to default for local runs
     if "SYC_IMAGE_TAG" not in os.environ:
-        monkeypatch.setenv("SYC_IMAGE_TAG", "v25.2.0-sp03")
+        monkeypatch.setenv("SYC_IMAGE_TAG", "v26.1.0")

--- a/tests/test_grpc_transport.py
+++ b/tests/test_grpc_transport.py
@@ -408,7 +408,10 @@ class TestStartupAndConnectionInfo:
         channel = info.get_server_channel()
 
         # Verify channel was created and logging occurred
-        mock_log.info.assert_called_once()
+        expected_info_calls = (
+            2 if os.environ.get("PYSYC_GRPC_CHANNEL_OPTIONS_JSON") else 1
+        )
+        assert mock_log.info.call_count == expected_info_calls
         self.mock_create_channel.assert_called_once()
         # The channel should be what create_channel returns
         assert channel == self.mock_create_channel.return_value
@@ -427,7 +430,10 @@ class TestStartupAndConnectionInfo:
 
         # Verify warnings and channel creation
         mock_log.warning.assert_called_once()
-        mock_log.info.assert_called_once()
+        expected_info_calls = (
+            2 if os.environ.get("PYSYC_GRPC_CHANNEL_OPTIONS_JSON") else 1
+        )
+        assert mock_log.info.call_count == expected_info_calls
         self.mock_create_channel.assert_called_once()
         assert channel is not None
 

--- a/tests/test_syc_container.py
+++ b/tests/test_syc_container.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import patch
+
+from ansys.systemcoupling.core.client.syc_container import start_container
+
+
+@patch("ansys.systemcoupling.core.client.syc_container.subprocess.run")
+def test_start_container_gh_actions_261_uses_host_network(
+    mock_subprocess_run,
+):
+    with patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}, clear=False):
+        start_container(
+            mounted_from=".",
+            mounted_to="/working",
+            network="",
+            port=50051,
+            version="v26.1.0",
+        )
+
+    run_args = mock_subprocess_run.call_args.args[0]
+
+    assert "--network=host" in run_args
+    assert "-p" not in run_args
+
+
+@patch("ansys.systemcoupling.core.client.syc_container.LOG")
+@patch("ansys.systemcoupling.core.client.syc_container.subprocess.run")
+def test_start_container_ignores_custom_network_when_host_network_active(
+    mock_subprocess_run,
+    mock_log,
+):
+    with patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}, clear=False):
+        start_container(
+            mounted_from=".",
+            mounted_to="/working",
+            network="custom-net",
+            port=50051,
+            version="v26.1.0",
+        )
+
+    run_args = mock_subprocess_run.call_args.args[0]
+
+    assert "--network=host" in run_args
+    assert "--network" not in run_args
+    mock_log.warning.assert_called_once_with(
+        "Ignoring 'network' argument because --network=host is active."
+    )
+
+
+@patch("ansys.systemcoupling.core.client.syc_container.subprocess.run")
+def test_start_container_applies_custom_network_when_port_mapping_active(
+    mock_subprocess_run,
+):
+    with patch.dict("os.environ", {}, clear=True):
+        start_container(
+            mounted_from=".",
+            mounted_to="/working",
+            network="custom-net",
+            port=50051,
+            version="v24.1.0",
+        )
+
+    run_args = mock_subprocess_run.call_args.args[0]
+
+    assert "-p" in run_args
+    assert "50051:50051" in run_args
+    assert "--network" in run_args
+    network_idx = run_args.index("--network")
+    assert run_args[network_idx + 1] == "custom-net"


### PR DESCRIPTION
Various changes to prepare for release targeting 26.1:

* Change various documentation to reflect newer version.
* Switch doc build to 26.1 and add 26.1 API build and unit testing.
* Drop API build and unit testing of 23.1/23.2.
* Change Fluent API calls in examples to remove deprecated forms.

On switching to the 26.1 container for doc builds and adding 26.1 unit tests, it was found that the long-running `Solve` RPC was failing intermittently and quite frequently. This appears to be related to gRPC timeouts and keepalive pings. Investigations showed that the solve itself was still running without issue on the server but the gRPC call timed out. These issues have so far only been seen when running on GitHub so there is possibly some element of resource constraints affecting the behaviour. gRPC exposes various parameters to tweak timeout and ping behaviour so these have been set for relevant github workflow tasks. However, the problem has not completely gone away so further mitigations were required.

To summarise what has been done:

* gRPC settings on the client side are defined in `ci.yml`. See `grpc_transport.py` for where these are applied.
* Sphinx Gallery retry logic has been introduced. If a gallery build fails it will be retried up to another two times but only failed examples will be rerun. This is achieved by not aborting the whole Sphinx Gallery run on a failed example, and by not running `make clean` on the second and third tries. This means that md5 files for successful example runs are not deleted, so Sphinx will not try to rerun them and will instead retain the earlier successful run.
* Similar, but more basic retry logic implemented for unit tests.